### PR TITLE
Feat/#12 : design system

### DIFF
--- a/apis/auth.ts
+++ b/apis/auth.ts
@@ -4,8 +4,8 @@ interface LoginPayload {
 }
 
 interface LoginResponse {
-  success: boolean;
-  code: string;
+  httpStatus?: number;
+  code?: string;
   message: string;
   data: {
     accessToken: string;
@@ -23,8 +23,8 @@ interface SignupPayload {
 }
 
 interface SignupResponse {
-  success: boolean;
-  code: string;
+  httpStatus?: number;
+  code?: string;
   message: string;
   data: {
     email: string;
@@ -33,19 +33,24 @@ interface SignupResponse {
 }
 
 export async function loginUser(payload: LoginPayload): Promise<LoginResponse> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(payload),
-  });
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/auth/login/form`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }
+  );
 
   const data = await res.json();
   return data;
 }
 
-export async function signupUser(payload: SignupPayload): Promise<SignupResponse> {
+export async function signupUser(
+  payload: SignupPayload
+): Promise<SignupResponse> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup`, {
     method: 'POST',
     headers: {

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -2,7 +2,7 @@ import { getTest } from '@/apis/test';
 
 const DashboardPage = async () => {
   const test = await getTest();
-  return <div className="text-primary">{test.message}</div>;
+  return <div className="text-primary headline-60-m">{test.message}</div>;
 };
 
 export default DashboardPage;

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,8 +1,8 @@
-import { getTest } from "@/apis/test";
+import { getTest } from '@/apis/test';
 
 const DashboardPage = async () => {
   const test = await getTest();
-  return <div>{test.message}</div>;
+  return <div className="text-primary">{test.message}</div>;
 };
 
 export default DashboardPage;

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -1,11 +1,9 @@
+'use client';
 
-
-"use client";
-
-import { useState } from "react";
-import Link from "next/link";
-import { Menu, X } from "lucide-react";
-import Image from "next/image";
+import { useState } from 'react';
+import Link from 'next/link';
+import { Menu, X } from 'lucide-react';
+import Image from 'next/image';
 
 export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
@@ -15,21 +13,39 @@ export default function NavBar() {
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-14">
           <Link href="/">
-            <Image src="/Logo.png" alt="Xpact" width={120} height={34} className="lg:h-[48px] lg:w-[170px]" />
+            <Image
+              src="/Logo.png"
+              alt="Xpact"
+              width={120}
+              height={34}
+              className="lg:h-[48px] lg:w-[170px]"
+            />
           </Link>
 
           <nav className="hidden md:flex space-x-6 text-[16px] lg:text-[20px] font-[Pretendard] text-white">
-            <Link href="/dashboard" className="hover:text-[#FF6D01]">대시보드</Link>
-            <Link href="/experience" className="hover:text-[#FF6D01]">내 경험</Link>
-            <Link href="/guide" className="hover:text-[#FF6D01]">성장 가이드</Link>
-            <Link href="/ai-intro" className="hover:text-[#FF6D01]">AI 자기소개서</Link>
-            <Link href="/mypage" className="hover:text-[#FF6D01]">마이페이지</Link>
+            <Link href="/dashboard" className="hover:text-[#FF6D01]">
+              대시보드
+            </Link>
+            <Link href="/experience" className="hover:text-[#FF6D01]">
+              내 경험
+            </Link>
+            <Link href="/guide" className="hover:text-[#FF6D01]">
+              성장 가이드
+            </Link>
+            <Link href="/ai-intro" className="hover:text-[#FF6D01]">
+              AI 자기소개서
+            </Link>
+            <Link href="/mypage" className="hover:text-[#FF6D01]">
+              마이페이지
+            </Link>
           </nav>
         </div>
 
         <div className="flex items-center">
           <div className="hidden md:block text-[16px] lg:text-[20px] font-[Pretendard] text-white">
-            <Link href="/login" className="hover:text-[#FF6D01]">로그인</Link>
+            <Link href="/login" className="hover:text-[#FF6D01]">
+              로그인
+            </Link>
           </div>
 
           <button
@@ -44,12 +60,48 @@ export default function NavBar() {
 
       {isOpen && (
         <div className="md:hidden mt-4 flex flex-col space-y-3 text-white font-[Pretendard] text-[16px]">
-          <Link href="/dashboard" onClick={() => setIsOpen(false)} className="hover:text-[#FF6D01]">대시보드</Link>
-          <Link href="/experience" onClick={() => setIsOpen(false)} className="hover:text-[#FF6D01]">내 경험</Link>
-          <Link href="/guide" onClick={() => setIsOpen(false)} className="hover:text-[#FF6D01]">성장 가이드</Link>
-          <Link href="/aiintro" onClick={() => setIsOpen(false)} className="hover:text-[#FF6D01]">AI 자기소개서</Link>
-          <Link href="/mypage" onClick={() => setIsOpen(false)} className="hover:text-[#FF6D01]">마이페이지</Link>
-          <Link href="/login" onClick={() => setIsOpen(false)} className="hover:text-[#FF6D01]">로그인</Link>
+          <Link
+            href="/dashboard"
+            onClick={() => setIsOpen(false)}
+            className="hover:text-[#FF6D01]"
+          >
+            대시보드
+          </Link>
+          <Link
+            href="/experience"
+            onClick={() => setIsOpen(false)}
+            className="hover:text-[#FF6D01]"
+          >
+            내 경험
+          </Link>
+          <Link
+            href="/guide"
+            onClick={() => setIsOpen(false)}
+            className="hover:text-[#FF6D01]"
+          >
+            성장 가이드
+          </Link>
+          <Link
+            href="/aiintro"
+            onClick={() => setIsOpen(false)}
+            className="hover:text-[#FF6D01]"
+          >
+            AI 자기소개서
+          </Link>
+          <Link
+            href="/mypage"
+            onClick={() => setIsOpen(false)}
+            className="hover:text-[#FF6D01]"
+          >
+            마이페이지
+          </Link>
+          <Link
+            href="/login"
+            onClick={() => setIsOpen(false)}
+            className="hover:text-[#FF6D01]"
+          >
+            로그인
+          </Link>
         </div>
       )}
     </header>

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -9,47 +9,47 @@ export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <header className="px-[5%] py-4 border-b border-gray-800 bg-black">
+    <header className="px-[5%] py-4 bg-gray-900">
       <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-14">
+        <div className="flex items-center space-x-[41px]">
           <Link href="/">
             <Image
               src="/Logo.png"
               alt="Xpact"
-              width={120}
-              height={34}
-              className="lg:h-[48px] lg:w-[170px]"
+              width={170}
+              height={48}
+              className="h-[48px] w-[170px]"
             />
           </Link>
 
-          <nav className="hidden md:flex space-x-6 text-[16px] lg:text-[20px] font-[Pretendard] text-white">
-            <Link href="/dashboard" className="hover:text-[#FF6D01]">
+          <nav className="hidden md:flex space-x-6 text-[16px] text-gray-50">
+            <Link href="/dashboard" className="hover:text-primary-100">
               대시보드
             </Link>
-            <Link href="/experience" className="hover:text-[#FF6D01]">
+            <Link href="/experience" className="hover:text-primary-100">
               내 경험
             </Link>
-            <Link href="/guide" className="hover:text-[#FF6D01]">
+            <Link href="/guide" className="hover:text-primary-100">
               성장 가이드
             </Link>
-            <Link href="/ai-intro" className="hover:text-[#FF6D01]">
+            <Link href="/ai-intro" className="hover:text-primary-100">
               AI 자기소개서
             </Link>
-            <Link href="/mypage" className="hover:text-[#FF6D01]">
+            <Link href="/mypage" className="hover:text-primary-100">
               마이페이지
             </Link>
           </nav>
         </div>
 
         <div className="flex items-center">
-          <div className="hidden md:block text-[16px] lg:text-[20px] font-[Pretendard] text-white">
-            <Link href="/login" className="hover:text-[#FF6D01]">
+          <div className="hidden md:block text-[16px] text-gray-50">
+            <Link href="/login" className="hover:text-primary-100">
               로그인
             </Link>
           </div>
 
           <button
-            className="md:hidden text-white"
+            className="md:hidden text-gray-50"
             onClick={() => setIsOpen(!isOpen)}
             aria-label="Toggle Menu"
           >
@@ -59,46 +59,46 @@ export default function NavBar() {
       </div>
 
       {isOpen && (
-        <div className="md:hidden mt-4 flex flex-col space-y-3 text-white font-[Pretendard] text-[16px]">
+        <div className="md:hidden mt-4 flex flex-col space-y-3 text-gray-50 text-[16px]">
           <Link
             href="/dashboard"
             onClick={() => setIsOpen(false)}
-            className="hover:text-[#FF6D01]"
+            className="hover:text-primary-100"
           >
             대시보드
           </Link>
           <Link
             href="/experience"
             onClick={() => setIsOpen(false)}
-            className="hover:text-[#FF6D01]"
+            className="hover:text-primary-100"
           >
             내 경험
           </Link>
           <Link
             href="/guide"
             onClick={() => setIsOpen(false)}
-            className="hover:text-[#FF6D01]"
+            className="hover:text-primary-100"
           >
             성장 가이드
           </Link>
           <Link
             href="/aiintro"
             onClick={() => setIsOpen(false)}
-            className="hover:text-[#FF6D01]"
+            className="hover:text-primary-100"
           >
             AI 자기소개서
           </Link>
           <Link
             href="/mypage"
             onClick={() => setIsOpen(false)}
-            className="hover:text-[#FF6D01]"
+            className="hover:text-primary-100"
           >
             마이페이지
           </Link>
           <Link
             href="/login"
             onClick={() => setIsOpen(false)}
-            className="hover:text-[#FF6D01]"
+            className="hover:text-primary-100"
           >
             로그인
           </Link>

--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -9,7 +9,7 @@ export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <header className="px-[5%] py-4 bg-gray-900">
+    <header className="px-[5%] py-4 bg-gray-900 body-16-r">
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-[41px]">
           <Link href="/">
@@ -22,7 +22,7 @@ export default function NavBar() {
             />
           </Link>
 
-          <nav className="hidden md:flex space-x-6 text-[16px] text-gray-50">
+          <nav className="hidden md:flex space-x-6 text-gray-50">
             <Link href="/dashboard" className="hover:text-primary-100">
               대시보드
             </Link>
@@ -42,7 +42,7 @@ export default function NavBar() {
         </div>
 
         <div className="flex items-center">
-          <div className="hidden md:block text-[16px] text-gray-50">
+          <div className="hidden md:block text-gray-50">
             <Link href="/login" className="hover:text-primary-100">
               로그인
             </Link>
@@ -59,7 +59,7 @@ export default function NavBar() {
       </div>
 
       {isOpen && (
-        <div className="md:hidden mt-4 flex flex-col space-y-3 text-gray-50 text-[16px]">
+        <div className="md:hidden mt-4 flex flex-col space-y-3 text-gray-50">
           <Link
             href="/dashboard"
             onClick={() => setIsOpen(false)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,102 @@
   --color-primary: rgb(255, 109, 1);
   --color-primary-50: rgb(255, 109, 1);
   --color-primary-100: rgb(255, 109, 1);
+
+  /* 타이포그래피 시스템 */
+
+  /* Headline */
+  --font-headline-60-m: 600 60px/130% sans-serif;
+  --tracking-headline-60-m: -0.04em;
+
+  /* Title */
+  --font-title-40-m: 500 40px/150% sans-serif;
+  --tracking-title-40-m: -0.02em;
+
+  --font-title-30-m: 500 30px/106% sans-serif;
+  --tracking-title-30-m: 0em;
+
+  /* Body */
+  --font-body-23-b: 700 23px/104% sans-serif;
+  --tracking-body-23-b: 0em;
+
+  --font-body-20-r: 400 20px/155% sans-serif;
+  --tracking-body-20-r: -0.02em;
+
+  --font-body-18-m: 500 18px/133% sans-serif;
+  --tracking-body-18-m: 0em;
+
+  --font-body-16-sb: 600 16px/150% sans-serif;
+  --tracking-body-16-sb: 0em;
+
+  --font-body-16-r: 400 16px/150% sans-serif;
+  --tracking-body-16-r: 0em;
+
+  --font-body-14-m: 500 14px/171% sans-serif;
+  --tracking-body-14-m: 0em;
+
+  --font-body-12-m: 500 12px/117% sans-serif;
+  --tracking-body-12-m: -0.025em;
+
+  --font-body-12-r: 400 12px/150% sans-serif;
+  --tracking-body-12-r: 0em;
+
+  /* Pretendard 폰트 */
+  --font-pretendard: 'Pretendard Variable', sans-serif;
+}
+
+.headline-60-m {
+  font: var(--font-headline-60-m);
+  letter-spacing: var(--tracking-headline-60-m);
+}
+
+.title-40-m {
+  font: var(--font-title-40-m);
+  letter-spacing: var(--tracking-title-40-m);
+}
+
+.title-30-m {
+  font: var(--font-title-30-m);
+  letter-spacing: var(--tracking-title-30-m);
+}
+
+.body-23-b {
+  font: var(--font-body-23-b);
+  letter-spacing: var(--tracking-body-23-b);
+}
+
+.body-20-r {
+  font: var(--font-body-20-r);
+  letter-spacing: var(--tracking-body-20-r);
+}
+
+.body-18-m {
+  font: var(--font-body-18-m);
+  letter-spacing: var(--tracking-body-18-m);
+}
+
+.body-16-sb {
+  font: var(--font-body-16-sb);
+  letter-spacing: var(--tracking-body-16-sb);
+}
+
+.body-16-r {
+  font: var(--font-body-16-r);
+  letter-spacing: var(--tracking-body-16-r);
+}
+
+.body-14-m {
+  font: var(--font-body-14-m);
+  letter-spacing: var(--tracking-body-14-m);
+}
+
+.body-12-m {
+  font: var(--font-body-12-m);
+  letter-spacing: var(--tracking-body-12-m);
+}
+
+.body-12-r {
+  font: var(--font-body-12-r);
+  letter-spacing: var(--tracking-body-12-r);
 }
 
 :root {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,36 @@
-@import "tailwindcss";
+@import 'tailwindcss';
+
+@theme {
+  /* Gray 색상 */
+  --color-gray-50: rgb(255, 255, 255);
+  --color-gray-50-10: rgb(255, 255, 255, 0.1);
+  --color-gray-100: rgb(217, 217, 217);
+  --color-gray-200: rgb(205, 205, 205);
+  --color-gray-300: rgb(153, 153, 153);
+  --color-gray-400: rgb(117, 117, 117);
+  --color-gray-500: rgb(102, 102, 102);
+  --color-gray-600: rgb(36, 36, 36);
+  --color-gray-700: rgb(22, 22, 22);
+  --color-gray-800: rgb(17, 17, 17);
+  --color-gray-900: rgb(2, 2, 2);
+  --color-gray-1000: rgb(0, 0, 0);
+
+  /* Success 색상 */
+  --color-success: rgb(4, 207, 93);
+
+  /* Error 색상 */
+  --color-error: rgb(238, 53, 53);
+
+  /* Primary 색상 */
+  --color-primary: rgb(255, 109, 1);
+  --color-primary-50: rgb(255, 109, 1);
+  --color-primary-100: rgb(255, 109, 1);
+}
 
 :root {
   --background: #0a0a0a;
   --foreground: #ededed;
-  --font-pretendard: "Pretendard Variable", sans-serif;
+  --font-pretendard: 'Pretendard Variable', sans-serif;
 }
 
 body {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 
 @theme {
+  /* Color System */
+
   /* Gray 색상 */
   --color-gray-50: rgb(255, 255, 255);
   --color-gray-50-10: rgb(255, 255, 255, 0.1);
@@ -26,7 +28,7 @@
   --color-primary-50: rgb(255, 109, 1);
   --color-primary-100: rgb(255, 109, 1);
 
-  /* 타이포그래피 시스템 */
+  /* Type System */
 
   /* Headline */
   --font-headline-60-m: 600 60px/130% sans-serif;
@@ -124,8 +126,8 @@
 }
 
 :root {
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  --background: var(--color-gray-900);
+  --foreground: var(--color-gray-50);
   --font-pretendard: 'Pretendard Variable', sans-serif;
 }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage() {
   const handleLogin = async () => {
     try {
       const data = await loginUser({ email, password });
-  
+
       if (data.success) {
         alert('로그인 성공!');
         localStorage.setItem('accessToken', data.data.accessToken);
@@ -37,7 +37,13 @@ export default function LoginPage() {
       <NavBar />
       <main className="flex flex-col items-center justify-center py-14 px-4">
         <div className="flex flex-col items-center mb-10">
-          <Image src="/logo2.png" alt="Xpact" width={59} height={48} className="mb-4" />
+          <Image
+            src="/logo2.png"
+            alt="Xpact"
+            width={59}
+            height={48}
+            className="mb-4"
+          />
           <h1 className="text-[35px] font-semibold">로그인</h1>
         </div>
 
@@ -48,7 +54,7 @@ export default function LoginPage() {
               type="text"
               placeholder="아이디"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={e => setEmail(e.target.value)}
             />
           </div>
           <div>
@@ -57,7 +63,7 @@ export default function LoginPage() {
               type="password"
               placeholder="비밀번호"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={e => setPassword(e.target.value)}
             />
           </div>
 
@@ -70,8 +76,10 @@ export default function LoginPage() {
         </div>
 
         <div className="mt-6 text-[14px] text-gray-400">
-          계정이 없으신가요?{" "}
-          <a href="/signup" className="text-[#FF6D01] font-medium">회원가입</a>
+          계정이 없으신가요?{' '}
+          <a href="/signup" className="text-[#FF6D01] font-medium">
+            회원가입
+          </a>
         </div>
 
         <div className="mt-[8%]">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -18,8 +18,9 @@ export default function LoginPage() {
   const handleLogin = async () => {
     try {
       const data = await loginUser({ email, password });
+      console.log(data);
 
-      if (data.success) {
+      if (data.httpStatus == 200) {
         alert('로그인 성공!');
         localStorage.setItem('accessToken', data.data.accessToken);
         router.push('/dashboard');
@@ -69,14 +70,14 @@ export default function LoginPage() {
 
           <button
             onClick={handleLogin}
-            className="w-full mt-[8%] py-3 bg-[#FF6D03] hover:bg-[#e45e00] text-[18px] font-semibold rounded"
+            className="w-full mt-[8%] py-3 bg-primary hover:bg-primary-100 text-[18px] font-semibold rounded"
           >
             로그인
           </button>
         </div>
 
         <div className="mt-6 text-[14px] text-gray-400">
-          계정이 없으신가요?{' '}
+          계정이 없으신가요?
           <a href="/signup" className="text-[#FF6D01] font-medium">
             회원가입
           </a>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -5,12 +5,12 @@ import ProfileImage from '../components/ProfileImage';
 
 export default function ProfilePage() {
   return (
-    <div className="min-h-screen bg-black text-white font-[Pretendard]">
+    <div className="min-h-screen">
       <NavBar />
       <main className="flex flex-col items-center justify-center py-14 px-4">
         <div className="flex flex-col items-center mb-10">
           <h1 className="text-[35px] font-semibold mb-[15%]">프로필 설정</h1>
-          <ProfileImage/>
+          <ProfileImage />
         </div>
 
         <div className="w-[448px] space-y-5">
@@ -31,7 +31,7 @@ export default function ProfilePage() {
             <FormInput type="password" placeholder="직무" />
           </div>
 
-          <button className="w-full mt-[8%] py-3 bg-[#FF6D03] hover:bg-[#e45e00] text-[18px] font-semibold rounded">
+          <button className="w-full mt-[8%] py-3 bg-primary hover:bg-primary-100 text-[18px] font-semibold rounded">
             로그인
           </button>
         </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -33,8 +33,9 @@ export default function SignupPage() {
         type: 'FORM',
         role: 'ROLE_USER',
       });
+      console.log(data);
 
-      if (data.success) {
+      if (data.httpStatus == 200) {
         alert('회원가입 성공!');
         router.push('/login');
       } else {
@@ -46,13 +47,18 @@ export default function SignupPage() {
     }
   };
 
-
   return (
-    <div className="min-h-screen bg-black text-white font-[Pretendard]">
+    <div>
       <NavBar />
       <main className="flex flex-col items-center justify-center py-14 px-4">
         <div className="flex flex-col items-center mb-10">
-          <Image src="/logo2.png" alt="Xpact" width={59} height={48} className="mb-4" />
+          <Image
+            src="/logo2.png"
+            alt="Xpact"
+            width={59}
+            height={48}
+            className="mb-4"
+          />
           <h1 className="text-[35px] font-semibold">회원가입</h1>
         </div>
 
@@ -63,7 +69,7 @@ export default function SignupPage() {
               type="email"
               placeholder="example@email.com"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={e => setEmail(e.target.value)}
             />
           </div>
           <div>
@@ -72,7 +78,7 @@ export default function SignupPage() {
               type="text"
               placeholder="이름"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={e => setName(e.target.value)}
             />
           </div>
           <div>
@@ -81,7 +87,7 @@ export default function SignupPage() {
               type="password"
               placeholder="비밀번호"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={e => setPassword(e.target.value)}
             />
           </div>
           <div>
@@ -89,13 +95,13 @@ export default function SignupPage() {
               type="password"
               placeholder="비밀번호 확인"
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
+              onChange={e => setConfirmPassword(e.target.value)}
             />
           </div>
 
           <button
             onClick={handleSignup}
-            className="w-full mt-[8%] py-3 bg-[#FF6D03] hover:bg-[#e45e00] text-[18px] font-semibold rounded"
+            className="w-full mt-[8%] py-3 bg-primary hover:bg-primary-100 text-[18px] font-semibold rounded"
           >
             회원가입
           </button>

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,5 @@
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: ['@tailwindcss/postcss'],
 };
 
 export default config;


### PR DESCRIPTION
## 📌 연관된 이슈

- close #12 

## 📝작업 내용

- figma에 정리되어있는 디자인 시스템 tailwind에서 테마 적용했습니다

예를들어 figma에서 컴포넌트 디자인 확인했을 때
![image](https://github.com/user-attachments/assets/bb1eeb87-ec6e-4598-bc62-acc0c2be839d)
fill이 gray-900 이라고 적혀있으면 저희 프론트엔드 디자인 적용할 때도 bg-gray-900 으로 설정하면 똑같이 되도록 설정해뒀습니다

primary color인 주황색 적용할 때는 text-[#FF6D01]이 아니라, text-primary로 작성하는 식으로 작업해주세요!

테마 목록은 figma의 design system 부분과 global.css의 @ theme 부분 확인해주세요

그 외에도 figma에서 폰트가 headline-60-M일 경우 className에 headline-60-m입력하면 font size, weight, spacing 모두 똑같이 적용되도록 설정해뒀습니다.

- font-[Pretendard]를 입력하지 않아도 모든 font에 pretendard 적용
- 기본 배경 색상을 bg-gray-900, 기본 글자 색상을 text-gray-50으로 설정해 각 컴포넌트에 색상 설정을 중복으로 하지 않아도 되도록 설정
- 기존 로그인 api url은 /login이었는데 /login/form 으로 변경되어 적용
- 원래 api dto에 sucess, code가 있었는데 success가 빠지고 code는 에러 시에만 오며, httpStatus가 추가되어 해당 변경사항 적용하여 회원가입/로그인 가능하도록 로직 수정


### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1983a0ad-acee-450c-8bdb-013d27e97797)
이렇게 입력하면
![image](https://github.com/user-attachments/assets/7ea84749-fe13-43c2-8df4-5b629d43b6f4)
요렇게 적용됩니당!


## 💬리뷰 요구사항
