### PR TITLE
Fix/#28 : build error fix - webpack 설정 변경

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,20 @@
-module.exports = {
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: [
+        {
+          loader: '@svgr/webpack',
+          options: {
+            icon: true,
+          },
+        },
+      ],
+    });
+    return config;
+  },
   experimental: {
     turbo: {
       rules: {
@@ -10,3 +26,5 @@ module.exports = {
     },
   },
 };
+
+export default nextConfig;


### PR DESCRIPTION
## 📌 연관된 이슈

- close #28

## 📝작업 내용

Error occurred prerendering page "/dashboard". Read more: https://nextjs.org/docs/messages/prerender-error
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.

nextjs 기본 세팅할 때 번들러를 turbopack으로 설정해뒀고 
svg 라이브러리를 위해 config도 turbo로 설정을 해뒀는데
https://nextjs.org/docs/app/api-reference/config/next-config-js/turbo

turbopack은 next build 지원이 안된다고 하더라구요
https://nextjs.org/docs/app/api-reference/turbopack

그래서 next dev --turbopack할 때는 turbo 적용하고 next build 할 때는 일반 webpack config 사용하게 수정했습니다
https://github.com/vercel/next.js/discussions/50337

로컬에서 npm run build 하고 npm run start로 실행했을 때 에러 안나는건 확인했는데 배포까지 될지는...

### 스크린샷 (선택)

## 💬리뷰 요구사항
