### PR TITLE
Feat/#19: 경험 입력 API 연결(token 추가)

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -28,15 +28,21 @@ export interface ExperiencePayload {
 interface ExperienceResponse {
   httpStatus: number;
   message: string;
+  data: {
+    accessToken: string;
+  };
 }
 
 export async function saveExperience(
   payload: ExperiencePayload
 ): Promise<ExperienceResponse> {
+  const token = localStorage.getItem('accessToken');
+
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/exp`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({
       ...payload,

--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -1,14 +1,14 @@
 export interface ExperiencePayload {
   status: 'DRAFT' | 'SAVE';
   experienceType:
-    | 'INTERN'
-    | 'EXTERNAL_ACTIVITIES'
     | 'CONTEST'
-    | 'PROJECT'
-    | 'CERTIFICATES'
+    | 'EXTERNAL_ACTIVITIES'
     | 'ACADEMIC_CLUB'
+    | 'INTERN'
+    | 'PROJECT'
     | 'EDUCATION'
     | 'PRIZE'
+    | 'CERTIFICATES'
     | 'VOLUNTEER_WORK'
     | 'STUDY_ABROAD'
     | 'ETC';

--- a/app/(main)/addExperience/components/ExperienceInputBox.tsx
+++ b/app/(main)/addExperience/components/ExperienceInputBox.tsx
@@ -36,17 +36,17 @@ export default function ExperienceInputBox({
 
 function SelectInput({ value, onChange }: ExperienceInputBoxProps) {
   const options = [
-    '공모전',
-    '대외활동',
-    '학회/동아리',
-    '인턴',
-    '프로젝트',
-    '교육',
-    '수상',
-    '자격증',
-    '봉사활동',
-    '해외경험',
-    '기타',
+    { label: '공모전', value: 'CONTEST' },
+    { label: '대외활동', value: 'EXTERNAL_ACTIVITIES' },
+    { label: '학회/동아리', value: 'ACADEMIC_CLUB' },
+    { label: '인턴', value: 'INTERN' },
+    { label: '프로젝트', value: 'PROJECT' },
+    { label: '교육', value: 'EDUCATION' },
+    { label: '수상', value: 'PRIZE' },
+    { label: '자격증', value: 'CERTIFICATES' },
+    { label: '봉사활동', value: 'VOLUNTEER_WORK' },
+    { label: '해외경험', value: 'STUDY_ABROAD' },
+    { label: '기타', value: 'ETC' },
   ];
 
   return (
@@ -57,13 +57,13 @@ function SelectInput({ value, onChange }: ExperienceInputBoxProps) {
           key={index}
           onClick={() =>
             onChange({
-              target: { value: option },
+              target: { value: option.value },
             } as React.ChangeEvent<HTMLSelectElement>)
           }
           className={`w-[120px] h-11 px-12 py-2.5 gap-[7px] rounded-lg border items-center justify-center inline-flex whitespace-nowrap
-            ${value === option ? 'bg-primary-50 text-gray-800 text-lg font-medium' : 'bg-gray-800 text-gray-300 border-gray-50-20 text-lg font-medium'}`}
+            ${value === option.value ? 'bg-primary-50 text-gray-800 text-lg font-medium' : 'bg-gray-800 text-gray-300 border-gray-50-20 text-lg font-medium'}`}
         >
-          {option}
+          {option.label}
         </button>
       ))}
     </div>

--- a/app/(main)/addExperience/page.tsx
+++ b/app/(main)/addExperience/page.tsx
@@ -16,7 +16,7 @@ export default function AddExperiencePage() {
     isModalOpen: false,
     status: 'SAVE',
     formType: 'STAR_FORM',
-    experienceType: 'INTERN',
+    experienceType: '',
     startDate: '',
     endDate: '',
     title: '',
@@ -48,15 +48,17 @@ export default function AddExperiencePage() {
         form.experienceType as ExperiencePayload['experienceType'],
       status: form.status as 'SAVE' | 'DRAFT',
     };
+
     try {
       const data = await saveExperience(payload);
+      console.log('서버 응답:', data);
 
-      if (data.httpStatus == 200) {
-        localStorage.setItem('accessToken', data.data.accessToken);
+      if (data?.httpStatus == 200) {
+        localStorage.setItem('accessToken', data?.data?.accessToken);
         alert('성공적으로 저장되었습니다!');
         router.push('/experience');
       } else {
-        alert(`저장 실패: ${data.message}`);
+        alert(`저장 실패: ${data?.message}`);
         console.log('보내는 payload:', payload);
       }
     } catch (err) {

--- a/app/(main)/addExperience/page.tsx
+++ b/app/(main)/addExperience/page.tsx
@@ -15,8 +15,8 @@ export default function AddExperiencePage() {
     selectedTab: 'star',
     isModalOpen: false,
     status: 'SAVE',
-    formType: '',
-    experienceType: '',
+    formType: 'STAR_FORM',
+    experienceType: 'INTERN',
     startDate: '',
     endDate: '',
     title: '',
@@ -38,25 +38,26 @@ export default function AddExperiencePage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('입력된 값:', form);
 
+    const payload: ExperiencePayload = {
+      ...form,
+      startDate: new Date(form.startDate),
+      endDate: new Date(form.endDate),
+      formType: form.formType as 'STAR_FORM' | 'SIMPLE_FORM',
+      experienceType:
+        form.experienceType as ExperiencePayload['experienceType'],
+      status: form.status as 'SAVE' | 'DRAFT',
+    };
     try {
-      const payload: ExperiencePayload = {
-        ...form,
-        startDate: new Date(form.startDate),
-        endDate: new Date(form.endDate),
-        formType: form.formType as 'STAR_FORM' | 'SIMPLE_FORM',
-        experienceType:
-          form.experienceType as ExperiencePayload['experienceType'],
-        status: form.status as 'SAVE' | 'DRAFT',
-      };
       const data = await saveExperience(payload);
 
       if (data.httpStatus == 200) {
+        localStorage.setItem('accessToken', data.data.accessToken);
         alert('성공적으로 저장되었습니다!');
         router.push('/experience');
       } else {
         alert(`저장 실패: ${data.message}`);
+        console.log('보내는 payload:', payload);
       }
     } catch (err) {
       console.error('저장 중 오류 발생:', err);


### PR DESCRIPTION
## 📌 연관된 이슈

- close #19 

## 📝작업 내용

token 추가하고 일부 에러 수정했습니다. 
로그인 후에 addExperience에서 경험 입력하고 작성 완료 누르면 저장 성공 팝업이 뜹니다.  

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/bb1dbb19-20b0-4389-b786-841ded1cbb35)

## 💬리뷰 요구사항
