### PR TITLE
Feat/#36 : 내 경험 api 연동

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -2,21 +2,27 @@
 
 import API from './config';
 
+export type ExperienceStatus = 'DRAFT' | 'SAVE';
+
+export type ExperienceType =
+  | 'CONTEST'
+  | 'EXTERNAL_ACTIVITIES'
+  | 'ACADEMIC_CLUB'
+  | 'INTERN'
+  | 'PROJECT'
+  | 'EDUCATION'
+  | 'PRIZE'
+  | 'CERTIFICATES'
+  | 'VOLUNTEER_WORK'
+  | 'STUDY_ABROAD'
+  | 'ETC';
+
+export type ExperienceFormType = 'STAR_FORM' | 'SIMPLE_FORM';
+
 export interface ExperiencePayload {
-  status: 'DRAFT' | 'SAVE';
-  experienceType:
-    | 'CONTEST'
-    | 'EXTERNAL_ACTIVITIES'
-    | 'ACADEMIC_CLUB'
-    | 'INTERN'
-    | 'PROJECT'
-    | 'EDUCATION'
-    | 'PRIZE'
-    | 'CERTIFICATES'
-    | 'VOLUNTEER_WORK'
-    | 'STUDY_ABROAD'
-    | 'ETC';
-  formType: 'STAR_FORM' | 'SIMPLE_FORM';
+  status: ExperienceStatus;
+  experienceType: ExperienceType;
+  formType: ExperienceFormType;
   title: string;
   startDate: Date;
   endDate: Date;
@@ -29,22 +35,37 @@ export interface ExperiencePayload {
   perform?: string;
 }
 
-interface ExperienceResponse {
+interface Experience {
+  id: number;
+  title: string;
+  experienceType: string;
+}
+
+interface SaveExperienceResponse {
   httpStatus: number;
   message: string;
-  data: {
-    accessToken: string;
-  };
+}
+
+interface GetExperienceResponse {
+  httpStatus: number;
+  message: string;
+  data: Experience[];
 }
 
 export async function saveExperience(
   payload: ExperiencePayload
-): Promise<ExperienceResponse> {
-  const res = await API.post<ExperienceResponse>('/api/exp', {
+): Promise<SaveExperienceResponse> {
+  const res = await API.post<SaveExperienceResponse>('/api/exp', {
     ...payload,
     startDate: new Date(payload.startDate),
     endDate: new Date(payload.endDate),
   });
 
+  return res.data;
+}
+
+export async function getMyExperience(): Promise<GetExperienceResponse> {
+  const res = await API.get<GetExperienceResponse>('/api/exp');
+  console.log(res.data);
   return res.data;
 }

--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -1,23 +1,11 @@
 'use server';
 
+import {
+  ExperienceFormType,
+  ExperienceStatus,
+  ExperienceType,
+} from '@/types/exp';
 import API from './config';
-
-export type ExperienceStatus = 'DRAFT' | 'SAVE';
-
-export type ExperienceType =
-  | 'CONTEST'
-  | 'EXTERNAL_ACTIVITIES'
-  | 'ACADEMIC_CLUB'
-  | 'INTERN'
-  | 'PROJECT'
-  | 'EDUCATION'
-  | 'PRIZE'
-  | 'CERTIFICATES'
-  | 'VOLUNTEER_WORK'
-  | 'STUDY_ABROAD'
-  | 'ETC';
-
-export type ExperienceFormType = 'STAR_FORM' | 'SIMPLE_FORM';
 
 export interface ExperiencePayload {
   status: ExperienceStatus;

--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -35,10 +35,10 @@ export interface ExperiencePayload {
   perform?: string;
 }
 
-interface Experience {
+export interface Experience {
   id: number;
   title: string;
-  experienceType: string;
+  experienceType: ExperienceType;
 }
 
 interface SaveExperienceResponse {
@@ -66,6 +66,5 @@ export async function saveExperience(
 
 export async function getMyExperience(): Promise<GetExperienceResponse> {
   const res = await API.get<GetExperienceResponse>('/api/exp');
-  console.log(res.data);
   return res.data;
 }

--- a/app/(main)/addExperience/components/ExperienceInputBox.tsx
+++ b/app/(main)/addExperience/components/ExperienceInputBox.tsx
@@ -1,3 +1,4 @@
+import { EXPERIENCE_OPTIONS } from '@/constants/experienceOptions';
 import React from 'react';
 
 interface ExperienceInputBoxProps {
@@ -35,19 +36,7 @@ export default function ExperienceInputBox({
 }
 
 function SelectInput({ value, onChange }: ExperienceInputBoxProps) {
-  const options = [
-    { label: '공모전', value: 'CONTEST' },
-    { label: '대외활동', value: 'EXTERNAL_ACTIVITIES' },
-    { label: '학회/동아리', value: 'ACADEMIC_CLUB' },
-    { label: '인턴', value: 'INTERN' },
-    { label: '프로젝트', value: 'PROJECT' },
-    { label: '교육', value: 'EDUCATION' },
-    { label: '수상', value: 'PRIZE' },
-    { label: '자격증', value: 'CERTIFICATES' },
-    { label: '봉사활동', value: 'VOLUNTEER_WORK' },
-    { label: '해외경험', value: 'STUDY_ABROAD' },
-    { label: '기타', value: 'ETC' },
-  ];
+  const options = Object.values(EXPERIENCE_OPTIONS);
 
   return (
     <div className="grid grid-cols-6 gap-2">

--- a/app/(main)/addExperience/page.tsx
+++ b/app/(main)/addExperience/page.tsx
@@ -8,6 +8,11 @@ import ExperienceInputBox from './components/ExperienceInputBox';
 import Footer from '@/app/components/Footer';
 import BackIcon from '@/public/icons/Chevron_Left.svg';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
+import {
+  ExperienceFormType,
+  ExperienceStatus,
+  ExperienceType,
+} from '@/types/exp';
 
 export default function AddExperiencePage() {
   const router = useRouter();
@@ -43,10 +48,9 @@ export default function AddExperiencePage() {
       ...form,
       startDate: new Date(form.startDate),
       endDate: new Date(form.endDate),
-      formType: form.formType as 'STAR_FORM' | 'SIMPLE_FORM',
-      experienceType:
-        form.experienceType as ExperiencePayload['experienceType'],
-      status: form.status as 'SAVE' | 'DRAFT',
+      formType: form.formType as ExperienceFormType,
+      experienceType: form.experienceType as ExperienceType,
+      status: form.status as ExperienceStatus,
     };
 
     const data = await saveExperience(payload);

--- a/app/(main)/experience/components/ExpType.tsx
+++ b/app/(main)/experience/components/ExpType.tsx
@@ -1,0 +1,11 @@
+import { ExperienceType } from '@/apis/exp';
+import { EXPERIENCE_OPTIONS } from '@/constants/experienceOptions';
+
+export default function ExpType({ expType }: { expType: ExperienceType }) {
+  const label = EXPERIENCE_OPTIONS[expType]?.label || expType;
+  return (
+    <div className="body-12-r py-1 text-center font-semibold rounded-full text-pink-200 bg-pink-900 w-[79px]">
+      {label}
+    </div>
+  );
+}

--- a/app/(main)/experience/components/ExpType.tsx
+++ b/app/(main)/experience/components/ExpType.tsx
@@ -1,5 +1,5 @@
-import { ExperienceType } from '@/apis/exp';
 import { EXPERIENCE_OPTIONS } from '@/constants/experienceOptions';
+import { ExperienceType } from '@/types/exp';
 
 export default function ExpType({ expType }: { expType: ExperienceType }) {
   const label = EXPERIENCE_OPTIONS[expType]?.label || expType;

--- a/app/(main)/experience/page.tsx
+++ b/app/(main)/experience/page.tsx
@@ -1,10 +1,10 @@
-import { getMyExperience } from '@/apis/exp';
+import { Experience, getMyExperience } from '@/apis/exp';
 import { Card, CardHeader, CardTitle, CardFooter } from './components/ExpCard';
 import { MoreVertical } from 'lucide-react';
+import ExpType from './components/ExpType';
 
 export default async function ExpMainPage() {
   const data = await getMyExperience();
-  console.log(data);
   return (
     <div className="min-h-screen bg-black text-[#FFFFFF] flex">
       <main className="flex-1 flex-col items-start py-16 px-8">
@@ -13,32 +13,17 @@ export default async function ExpMainPage() {
         </h1>
 
         <div className="w-full flex flex-row space-x-4 overflow-x-auto">
-          <Card className="bg-[#2C2C2C] text-white">
-            <CardHeader className="mb-13">
-              <CardTitle>경험 1</CardTitle>
-            </CardHeader>
-            <CardFooter className="justify-end">
-              <MoreVertical />
-            </CardFooter>
-          </Card>
-
-          <Card className="bg-[#2C2C2C] text-white">
-            <CardHeader className="mb-13">
-              <CardTitle>경험 2</CardTitle>
-            </CardHeader>
-            <CardFooter className="justify-end">
-              <MoreVertical />
-            </CardFooter>
-          </Card>
-
-          <Card className="bg-[#2C2C2C] text-white">
-            <CardHeader className="mb-13">
-              <CardTitle>경험 3</CardTitle>
-            </CardHeader>
-            <CardFooter className="justify-end">
-              <MoreVertical />
-            </CardFooter>
-          </Card>
+          {data.data.map((experience: Experience) => (
+            <Card key={experience.id} className="bg-[#2C2C2C] text-white">
+              <CardHeader className="mb-13">
+                <CardTitle>{experience.title}</CardTitle>
+              </CardHeader>
+              <CardFooter className="justify-end">
+                <ExpType expType={experience.experienceType} />
+                <MoreVertical />
+              </CardFooter>
+            </Card>
+          ))}
         </div>
       </main>
     </div>

--- a/app/(main)/experience/page.tsx
+++ b/app/(main)/experience/page.tsx
@@ -2,14 +2,20 @@ import { Experience, getMyExperience } from '@/apis/exp';
 import { Card, CardHeader, CardTitle, CardFooter } from './components/ExpCard';
 import { MoreVertical } from 'lucide-react';
 import ExpType from './components/ExpType';
+import Link from 'next/link';
 
 export default async function ExpMainPage() {
   const data = await getMyExperience();
   return (
-    <div className="min-h-screen bg-black text-[#FFFFFF] flex">
+    <div className="min-h-screen flex">
       <main className="flex-1 flex-col items-start py-16 px-8">
-        <h1 className="text-[25px] font-bold font-[Pretendard] mb-10">
-          내 경험
+        <h1 className="text-[25px] font-bold mb-10 flex items-center justify-between">
+          <span>내 경험</span>
+          <Link href="/addExperience">
+            <div className="w-20 py-3 bg-primary-50 text-sm text-black text-center font-semibold rounded-lg flex items-center justify-center">
+              경험 추가
+            </div>
+          </Link>
         </h1>
 
         <div className="w-full flex flex-row space-x-4 overflow-x-auto">

--- a/app/(main)/experience/page.tsx
+++ b/app/(main)/experience/page.tsx
@@ -1,7 +1,10 @@
+import { getMyExperience } from '@/apis/exp';
 import { Card, CardHeader, CardTitle, CardFooter } from './components/ExpCard';
 import { MoreVertical } from 'lucide-react';
 
-export default function ExpMainPage() {
+export default async function ExpMainPage() {
+  const data = await getMyExperience();
+  console.log(data);
   return (
     <div className="min-h-screen bg-black text-[#FFFFFF] flex">
       <main className="flex-1 flex-col items-start py-16 px-8">

--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -43,9 +43,15 @@ const SideBar = () => {
           />
           <SideBarMenu
             href="/experience"
-            icon={<BookIcon className={iconStyle('/experience')} />}
+            icon={
+              <BookIcon
+                className={`${pathname === '/experience' || pathname === '/addExperience' ? 'stroke-gray-50' : 'stroke-gray-300'} transition-colors group-hover:stroke-gray-50`}
+              />
+            }
             text="내 경험"
-            isActive={pathname === '/experience'}
+            isActive={
+              pathname === '/experience' || pathname === '/addExperience'
+            }
           />
           <SideBarMenu
             href="/experience"

--- a/constants/experienceOptions.ts
+++ b/constants/experienceOptions.ts
@@ -1,0 +1,13 @@
+export const EXPERIENCE_OPTIONS = {
+  CONTEST: { label: '공모전', value: 'CONTEST' },
+  EXTERNAL_ACTIVITIES: { label: '대외활동', value: 'EXTERNAL_ACTIVITIES' },
+  ACADEMIC_CLUB: { label: '학회/동아리', value: 'ACADEMIC_CLUB' },
+  INTERN: { label: '인턴', value: 'INTERN' },
+  PROJECT: { label: '프로젝트', value: 'PROJECT' },
+  EDUCATION: { label: '교육', value: 'EDUCATION' },
+  PRIZE: { label: '수상', value: 'PRIZE' },
+  CERTIFICATES: { label: '자격증', value: 'CERTIFICATES' },
+  VOLUNTEER_WORK: { label: '봉사활동', value: 'VOLUNTEER_WORK' },
+  STUDY_ABROAD: { label: '해외경험', value: 'STUDY_ABROAD' },
+  ETC: { label: '기타', value: 'ETC' },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.484.0",
-        "next": "15.2.3",
+        "next": "^15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "swiper": "^11.2.6",
@@ -2483,9 +2483,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.3.tgz",
-      "integrity": "sha512-a26KnbW9DFEUsSxAxKBORR/uD9THoYoKbkpFywMN/AFvboTt94b8+g/07T8J6ACsdLag8/PDU60ov4rPxRAixw==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
+      "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.3.tgz",
-      "integrity": "sha512-uaBhA8aLbXLqwjnsHSkxs353WrRgQgiFjduDpc7YXEU0B54IKx3vU+cxQlYwPCyC8uYEEX7THhtQQsfHnvv8dw==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
+      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
       "cpu": [
         "arm64"
       ],
@@ -2515,9 +2515,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.3.tgz",
-      "integrity": "sha512-pVwKvJ4Zk7h+4hwhqOUuMx7Ib02u3gDX3HXPKIShBi9JlYllI0nU6TWLbPT94dt7FSi6mSBhfc2JrHViwqbOdw==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
+      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
       "cpu": [
         "x64"
       ],
@@ -2531,9 +2531,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.3.tgz",
-      "integrity": "sha512-50ibWdn2RuFFkOEUmo9NCcQbbV9ViQOrUfG48zHBCONciHjaUKtHcYFiCwBVuzD08fzvzkWuuZkd4AqbvKO7UQ==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
+      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
       "cpu": [
         "arm64"
       ],
@@ -2547,9 +2547,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.3.tgz",
-      "integrity": "sha512-2gAPA7P652D3HzR4cLyAuVYwYqjG0mt/3pHSWTCyKZq/N/dJcUAEoNQMyUmwTZWCJRKofB+JPuDVP2aD8w2J6Q==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
+      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
       "cpu": [
         "arm64"
       ],
@@ -2563,9 +2563,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.3.tgz",
-      "integrity": "sha512-ODSKvrdMgAJOVU4qElflYy1KSZRM3M45JVbeZu42TINCMG3anp7YCBn80RkISV6bhzKwcUqLBAmOiWkaGtBA9w==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
+      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
       "cpu": [
         "x64"
       ],
@@ -2579,9 +2579,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.3.tgz",
-      "integrity": "sha512-ZR9kLwCWrlYxwEoytqPi1jhPd1TlsSJWAc+H/CJHmHkf2nD92MQpSRIURR1iNgA/kuFSdxB8xIPt4p/T78kwsg==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
+      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
       "cpu": [
         "x64"
       ],
@@ -2595,9 +2595,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.3.tgz",
-      "integrity": "sha512-+G2FrDcfm2YDbhDiObDU/qPriWeiz/9cRR0yMWJeTLGGX6/x8oryO3tt7HhodA1vZ8r2ddJPCjtLcpaVl7TE2Q==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
+      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
       "cpu": [
         "arm64"
       ],
@@ -2611,9 +2611,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.3.tgz",
-      "integrity": "sha512-gHYS9tc+G2W0ZC8rBL+H6RdtXIyk40uLiaos0yj5US85FNhbFEndMA2nW3z47nzOWiSvXTZ5kBClc3rD0zJg0w==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
+      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
       "cpu": [
         "x64"
       ],
@@ -6905,12 +6905,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.3.tgz",
-      "integrity": "sha512-x6eDkZxk2rPpu46E1ZVUWIBhYCLszmUY6fvHBFcbzJ9dD+qRX6vcHusaqqDlnY+VngKzKbAiG2iRCkPbmi8f7w==",
+      "version": "15.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.4.tgz",
+      "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.3",
+        "@next/env": "15.2.4",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -6925,14 +6925,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.3",
-        "@next/swc-darwin-x64": "15.2.3",
-        "@next/swc-linux-arm64-gnu": "15.2.3",
-        "@next/swc-linux-arm64-musl": "15.2.3",
-        "@next/swc-linux-x64-gnu": "15.2.3",
-        "@next/swc-linux-x64-musl": "15.2.3",
-        "@next/swc-win32-arm64-msvc": "15.2.3",
-        "@next/swc-win32-x64-msvc": "15.2.3",
+        "@next/swc-darwin-arm64": "15.2.4",
+        "@next/swc-darwin-x64": "15.2.4",
+        "@next/swc-linux-arm64-gnu": "15.2.4",
+        "@next/swc-linux-arm64-musl": "15.2.4",
+        "@next/swc-linux-x64-gnu": "15.2.4",
+        "@next/swc-linux-x64-musl": "15.2.4",
+        "@next/swc-win32-arm64-msvc": "15.2.4",
+        "@next/swc-win32-x64-msvc": "15.2.4",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.484.0",
-    "next": "15.2.3",
+    "next": "^15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "swiper": "^11.2.6",

--- a/types/exp.ts
+++ b/types/exp.ts
@@ -1,0 +1,16 @@
+export type ExperienceStatus = 'DRAFT' | 'SAVE';
+
+export type ExperienceType =
+  | 'CONTEST'
+  | 'EXTERNAL_ACTIVITIES'
+  | 'ACADEMIC_CLUB'
+  | 'INTERN'
+  | 'PROJECT'
+  | 'EDUCATION'
+  | 'PRIZE'
+  | 'CERTIFICATES'
+  | 'VOLUNTEER_WORK'
+  | 'STUDY_ABROAD'
+  | 'ETC';
+
+export type ExperienceFormType = 'STAR_FORM' | 'SIMPLE_FORM';


### PR DESCRIPTION
## 📌 연관된 이슈

- close #36

## 📝작업 내용

- 내 경험 api 연결
경험 작성 api가 연결되어서 시연할 때 경험 작성-> 작성한 경험 리스트 보여줄 수 있게 api 연결했습니다

- types 분리
```
  experienceType:
    | 'CONTEST'
    | 'EXTERNAL_ACTIVITIES'
    | 'ACADEMIC_CLUB'
    | 'INTERN'
    | 'PROJECT'
    | 'EDUCATION'
    | 'PRIZE'
    | 'CERTIFICATES'
    | 'VOLUNTEER_WORK'
    | 'STUDY_ABROAD'
    | 'ETC';
```
이렇게 길고 복잡한 타입이 반복되어 사용될 때는 매 파일마다 중복되게 작성하는 것 보다는 공통으로 사용할 수 있게 분리하면 좋을 것 같아 types 폴더 만들고 내부에 exp.ts 생성해서 분리했습니다! type 지정할 일 있으면 types 폴더 내에서 작성해주세요 ㅎㅎ
experienceType 쓰는 코드들 분리한 type 호출해서 사용하도록 수정했습니다

- constants 분리
```
const options = [
    { label: '공모전', value: 'CONTEST' },
    { label: '대외활동', value: 'EXTERNAL_ACTIVITIES' },
    { label: '학회/동아리', value: 'ACADEMIC_CLUB' },
    { label: '인턴', value: 'INTERN' },
    { label: '프로젝트', value: 'PROJECT' },
    { label: '교육', value: 'EDUCATION' },
    { label: '수상', value: 'PRIZE' },
    { label: '자격증', value: 'CERTIFICATES' },
    { label: '봉사활동', value: 'VOLUNTEER_WORK' },
    { label: '해외경험', value: 'STUDY_ABROAD' },
    { label: '기타', value: 'ETC' },
  ];
```
options 코드도 경험 작성할 때, 내 경험 타입 컴포넌트 만들 때 중복되게 사용되길래 재사용가능하도록 상수로 뽑아서 파일 분리했습니다!
```
export const EXPERIENCE_OPTIONS = {
  CONTEST: { label: '공모전', value: 'CONTEST' },
  EXTERNAL_ACTIVITIES: { label: '대외활동', value: 'EXTERNAL_ACTIVITIES' },
  ACADEMIC_CLUB: { label: '학회/동아리', value: 'ACADEMIC_CLUB' },
  INTERN: { label: '인턴', value: 'INTERN' },
  PROJECT: { label: '프로젝트', value: 'PROJECT' },
  EDUCATION: { label: '교육', value: 'EDUCATION' },
  PRIZE: { label: '수상', value: 'PRIZE' },
  CERTIFICATES: { label: '자격증', value: 'CERTIFICATES' },
  VOLUNTEER_WORK: { label: '봉사활동', value: 'VOLUNTEER_WORK' },
  STUDY_ABROAD: { label: '해외경험', value: 'STUDY_ABROAD' },
  ETC: { label: '기타', value: 'ETC' },
};
```
`const label = EXPERIENCE_OPTIONS[expType]?.label || expType;`
expType을 key로 사용해서  EXPERIENCE_OPTIONS['STUDY_ABROAD']?.label 을 호출하면 바로 '해외경험'이 나오게 했어요
const options = Object.values(EXPERIENCE_OPTIONS); 와 같이 Object.values를 이용하면 배열 형태로 반환하여 map도 가능합니다

- 경험 추가 버튼 추가
클릭하면 /addExperience로 이동하도록 버튼 달았어요
이거도 공통 컴포넌트로 분리하면 좋을 듯!

- next 버전 업데이트
https://github.com/Xpact-2025/FE/security/dependabot/2
next 15.2.4에서 보안 문제 있다고 해서 15.2.4로 업데이트 했습니다 npm i 로 패키지 재설치해주세요!

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/84178d40-8d43-4000-82f4-034ed57c3cff)


## 💬리뷰 요구사항

경험 저장 api 명이 saveExperience로 되어 있길래, 내 경험 api 명은 어떤 걸로 해야할까 고민해보았는데요...
경험을 가져오는 것이니 get으로 할지, getExperience로 할지 내 경험을 가져오는 것이니 myExperience로 할지 고민이 되더라구요
뭐가 좋을까요? ㅎㅎ