### PR TITLE
feat/#45: 내 경험 삭제 api 연동

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -56,3 +56,8 @@ export async function getMyExperience(): Promise<GetExperienceResponse> {
   const res = await API.get<GetExperienceResponse>('/api/exp');
   return res.data;
 }
+
+export async function deleteExperience(id: number) {
+  const res = await API.delete(`/api/exp/${id}`);
+  return res.data;
+}

--- a/app/(main)/experience/components/DropdownMenu.tsx
+++ b/app/(main)/experience/components/DropdownMenu.tsx
@@ -3,13 +3,17 @@
 import { useEffect, useRef } from 'react';
 import TrashFullIcon from '@/public/icons/Trash_Full.svg';
 import EditPencilIcon from '@/public/icons/Edit_Pencil_02.svg';
+import { useRouter } from 'next/navigation';
+import { deleteExperience } from '@/apis/exp';
 
 interface DropdownMenuProps {
+  id: number;
   onClose: () => void;
 }
 
-export default function DropdownMenu({ onClose }: DropdownMenuProps) {
+export default function DropdownMenu({ id, onClose }: DropdownMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
+  const router = useRouter();
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -24,6 +28,19 @@ export default function DropdownMenu({ onClose }: DropdownMenuProps) {
     };
   }, [onClose]);
 
+  const handleDelete = async () => {
+    const confirmed = window.confirm('정말 삭제하시겠습니까?');
+    if (!confirmed) return;
+    try {
+      await deleteExperience(id);
+      alert('삭제되었습니다.');
+      router.refresh();
+    } catch (error) {
+      console.error('삭제 중 오류 발생:', error);
+      alert('삭제에 실패했습니다.');
+    }
+  };
+
   return (
     <div
       ref={menuRef}
@@ -33,7 +50,10 @@ export default function DropdownMenu({ onClose }: DropdownMenuProps) {
         <EditPencilIcon className="stroke-gray-1000" />
         수정
       </button>
-      <button className="w-full text-left px-4 py-2 hover:bg-gray-300 flex items-center gap-2">
+      <button
+        onClick={handleDelete}
+        className="w-full text-left px-4 py-2 hover:bg-gray-300 flex items-center gap-2"
+      >
         <TrashFullIcon className="stroke-gray-1000" />
         삭제
       </button>

--- a/app/(main)/experience/components/ExperienceCard.tsx
+++ b/app/(main)/experience/components/ExperienceCard.tsx
@@ -7,12 +7,14 @@ import MoreVerticalIcon from '@/public/icons/More_Vertical.svg';
 import DropdownMenu from './DropdownMenu';
 
 interface ExperienceCardProps {
+  id: number;
   title: string;
   type: ExperienceType;
   isTemp?: boolean;
 }
 
 export default function ExperienceCard({
+  id,
   title,
   type,
   isTemp,
@@ -50,7 +52,7 @@ export default function ExperienceCard({
           <MoreVerticalIcon className="stroke-gray-50" />
         </button>
         {isDropdownOpen && (
-          <DropdownMenu onClose={() => setIsDropdownOpen(false)} />
+          <DropdownMenu id={id} onClose={() => setIsDropdownOpen(false)} />
         )}
       </div>
     </div>

--- a/app/(main)/experience/page.tsx
+++ b/app/(main)/experience/page.tsx
@@ -9,10 +9,6 @@ export default async function ExpMainPage() {
     return <div>오류가 발생했습니다.</div>;
   }
 
-  if (!data || data.length === 0) {
-    return <div>경험이 존재하지 않습니다.</div>;
-  }
-
   return (
     <div className="min-h-screen flex">
       <main className="flex-1 flex-col items-start py-16 px-[80px]">
@@ -21,10 +17,13 @@ export default async function ExpMainPage() {
           <BtnUpload href="/addExperience">경험 추가</BtnUpload>
         </h1>
 
+        {!data || (data.length === 0 && <div>경험이 존재하지 않습니다.</div>)}
+
         <div className="w-full flex flex-wrap space-x-[28px] space-y-[37px]">
-          {data.map((experience: Experience) => (
+          {data?.map((experience: Experience) => (
             <ExpeienceCard
               key={experience.id}
+              id={experience.id}
               title={experience.title}
               type={experience.experienceType}
               isTemp={false}


### PR DESCRIPTION
## 📌 연관된 이슈

- close #45

## 📝작업 내용

- 삭제 버튼 클릭 시 confirm 창 열림
- 확인 클릭 시 경험 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항

팝업 컴포넌트 작업 끝나시면 confirm 창으로 구현해뒀던 것 팝업 컴포넌트로 교체하겠습니다!
