### PR TITLE
feat/#63: keyword component 생성

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -11,7 +11,7 @@ export interface ExpPayload {
   title: string;
   startDate: Date;
   endDate: Date;
-  keyword: string;
+  keywords: string[];
   situation?: string;
   task?: string;
   action?: string;

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -10,6 +10,7 @@ import Footer from '@/app/components/Footer';
 import BackIcon from '@/public/icons/Chevron_Left.svg';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import { ExpFormType, ExpStatus, ExpType } from '@/types/exp';
+import KeywordInput from './KeywordInput';
 
 interface ExpFormProps {
   data?: ExpPayload;
@@ -32,7 +33,7 @@ export default function ExpForm({ data }: ExpFormProps) {
     task: data?.task || '',
     action: data?.action || '',
     result: data?.result || '',
-    keyword: data?.keyword || '',
+    keywords: data?.keywords || '',
     role: data?.role || '',
     perform: data?.perform || '',
   });
@@ -54,6 +55,7 @@ export default function ExpForm({ data }: ExpFormProps) {
       formType: form.formType as ExpFormType,
       experienceType: form.experienceType as ExpType,
       status: form.status as ExpStatus,
+      keywords: Array.isArray(form.keywords) ? form.keywords : [form.keywords],
     };
 
     const { httpStatus, message } = data?.id
@@ -286,12 +288,7 @@ export default function ExpForm({ data }: ExpFormProps) {
           <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
             키워드
           </div>
-          <ExpInputBox
-            type="string"
-            placeholder="#태그 입력 (최대 30개)"
-            value={form.keyword}
-            onChange={e => handleChange('keyword', e.target.value)}
-          />
+          <KeywordInput />
         </div>
         <Footer />
       </div>

--- a/app/(main)/addExp/components/KeywordInput.tsx
+++ b/app/(main)/addExp/components/KeywordInput.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function KeywordInput() {
+  const [input, setInput] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length <= 11) {
+      setInput(e.target.value);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && input !== '') {
+      e.preventDefault();
+      const trimmedInput = input.trim();
+
+      if (tags.length < 5 && !tags.includes(trimmedInput)) {
+        setTags(prevTags => [...prevTags, trimmedInput]);
+        setInput('');
+      }
+    } else if (e.key === 'Backspace' && input === '' && tags.length) {
+      const lastTag = tags[tags.length - 1];
+      setTags(prevTags => prevTags.slice(0, -1));
+      setInput(lastTag);
+    }
+  };
+
+  return (
+    <div className="w-full flex px-4 py-3 bg-gray-800 rounded border border-gray-700 placeholder:text-gray-300 gap-2.5">
+      {tags.map((tag, index) => (
+        <div
+          key={index}
+          className="h-6 px-2 bg-gray-300 rounded-[16px] inline-flex justify-center items-center text-gray-1100 text-sm"
+        >
+          {tag}
+        </div>
+      ))}
+      <input
+        value={input}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        placeholder="#태그 입력 (최대 5개)"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 연관된 이슈

- close #63 

## 📝작업 내용

keyword의 type이 string에서 string[]으로 바뀌어 수정하고
keywordInput 컴포넌트를 새로 생성하였습니다. 

키워드 입력 조건 
- 키워드 개수 최대 5개
- 키워드 최대 10글자
- enter 누르면 태그 생성
- backspace 누르면 태그 삭제
- 공백 제거 / 중복 제거

### 스크린샷 (선택)

키워드 입력 전
![image](https://github.com/user-attachments/assets/e7531cae-3ffa-4868-b7a0-7dc6fd117105)

키워드 입력 후 enter
![image](https://github.com/user-attachments/assets/0303b9a8-fd91-4e13-b2fa-8403460eceee)

## 💬리뷰 요구사항
