### PR TITLE
feat/#81: 직무 비율 API 연동

### DIFF
--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -1,0 +1,16 @@
+import API from './config';
+
+type JobRatioType = Record<string, number>;
+
+export interface JobRatioResponse {
+  httpStatus: number;
+  message: string;
+  data: {
+    ratios: JobRatioType;
+  };
+}
+
+export async function getJobRatio(): Promise<JobRatioResponse> {
+  const res = await API.get<JobRatioResponse>('/api/dashboard/ratio');
+  return res.data;
+}

--- a/app/(main)/dashboard/components/ChartContainer.tsx
+++ b/app/(main)/dashboard/components/ChartContainer.tsx
@@ -3,12 +3,19 @@
 import dynamic from 'next/dynamic';
 const JobRatio = dynamic(() => import('./JobRatio'), { ssr: false });
 const SkillMap = dynamic(() => import('./SkillMap'), { ssr: false });
+import { JobRatioResponse } from '@/apis/dashboard';
 
-export default function ChartContainer() {
+export default function ChartContainer({
+  jobRatio,
+}: {
+  jobRatio: JobRatioResponse;
+}) {
+  const jobRatioData = jobRatio.data.ratios;
+
   return (
     <div className="flex flex-wrap gap-4">
       <div className="flex-grow-4 bg-gray-800 rounded-[23px] py-8 px-10 h-[319px]">
-        <JobRatio />
+        <JobRatio jobRatioData={jobRatioData} />
       </div>
       <div className="flex-grow-6 bg-gray-800 rounded-[23px] py-8 px-10">
         <SkillMap />

--- a/app/(main)/dashboard/components/JobRatio.tsx
+++ b/app/(main)/dashboard/components/JobRatio.tsx
@@ -2,59 +2,18 @@
 
 import { Pie, PieChart, Cell, Label } from 'recharts';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
+import { JobRatioType } from '@/apis/dashboard';
 
-const data = [
-  { name: '기획', value: 40 },
-  { name: '마케팅', value: 25 },
-  { name: 'UX', value: 20 },
-  { name: '개발', value: 10 },
-];
-
-const COLORS = ['#FF6D01', '#CDCDCD', '#999999', '#757575'];
-
-function CustomLabel({
-  viewBox,
-  job = '',
+export default function JobRatio({
+  jobRatioData,
 }: {
-  viewBox: { cx: number; cy: number };
-  job?: string;
+  jobRatioData: JobRatioType;
 }) {
-  const { cx, cy } = viewBox;
-  return (
-    <>
-      <text>
-        <tspan
-          x={cx}
-          y={cy - 10}
-          textAnchor="middle"
-          style={{
-            fontWeight: 500,
-            fontSize: '14px',
-            fill: '#A9A9A9',
-            fontFamily: 'Pretendard',
-          }}
-        >
-          주요 직무
-        </tspan>
-        <tspan
-          x={cx}
-          y={cy + 20}
-          textAnchor="middle"
-          style={{
-            fontWeight: 700,
-            fontSize: '23px',
-            fill: '#CDCDCD',
-            fontFamily: 'Pretendard',
-          }}
-        >
-          {job}
-        </tspan>
-      </text>
-    </>
-  );
-}
+  const data = Object.entries(jobRatioData).map(([name, value]) => ({
+    name,
+    value,
+  }));
 
-export default function JobRatio() {
   return (
     <>
       <div className="flex mb-3">
@@ -112,6 +71,50 @@ export default function JobRatio() {
           </ul>
         </div>
       </div>
+    </>
+  );
+}
+
+const COLORS = ['#FF6D01', '#CDCDCD', '#999999', '#757575'];
+
+function CustomLabel({
+  viewBox,
+  job = '',
+}: {
+  viewBox: { cx: number; cy: number };
+  job?: string;
+}) {
+  const { cx, cy } = viewBox;
+  return (
+    <>
+      <text>
+        <tspan
+          x={cx}
+          y={cy - 10}
+          textAnchor="middle"
+          style={{
+            fontWeight: 500,
+            fontSize: '14px',
+            fill: '#A9A9A9',
+            fontFamily: 'Pretendard',
+          }}
+        >
+          주요 직무
+        </tspan>
+        <tspan
+          x={cx}
+          y={cy + 20}
+          textAnchor="middle"
+          style={{
+            fontWeight: 700,
+            fontSize: '23px',
+            fill: '#CDCDCD',
+            fontFamily: 'Pretendard',
+          }}
+        >
+          {job}
+        </tspan>
+      </text>
     </>
   );
 }

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -3,8 +3,11 @@ import ExpHistory from './components/ExpHistory';
 import Scrap from './components/Scrap';
 import ExpTimeLine from './components/ExpTimeLine';
 import ChartContainer from './components/ChartContainer';
+import { getJobRatio } from '@/apis/dashboard';
 
 export default async function DashboardPage() {
+  const jobRatio = await getJobRatio();
+
   return (
     <div className="min-h-screen py-6 px-14">
       <div className="flex flex-col gap-4">
@@ -26,7 +29,7 @@ export default async function DashboardPage() {
         </div>
 
         {/* 직무 비율, 핵심 스킬 맵 */}
-        <ChartContainer />
+        <ChartContainer jobRatio={jobRatio} />
 
         {/* 경험 타임라인 */}
         <div className="bg-gray-800 rounded-[23px] py-8 px-10">


### PR DESCRIPTION
## 📌 연관된 이슈

- close #81

## 📝작업 내용
- 직무 비율 API 연동
- 직무 비율이 Record 형태로 반환되길래 .entries().map()으로 배열 형태로 재가공 후 사용했습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/55a1647c-24cf-465e-aafc-3d700d965cc8)
테스트 데이터 아무거나 입력했는데 PM이 제일 비율이 높다고 뜨네요.. 신기합니다 ㅎ

## 💬리뷰 요구사항

recharts 라이브러리를 사용하면 hydration 에러가 발생하여 ssr을 false로 설정하고 dynamic으로 import 해와야하는데,
dynamic으로 import는 클라이언트 컴포넌트에서만 가능하여 ChartContainer 컴포넌트 생성 후 JobRatio 컴포넌트와 SkillMap 컴포넌트를 import 했습니다.
이렇게 구현하다보니 props drilling이 심해지는 것 같은데 어떻게 하는게 좋을지 고민이 되네요
