### PR TITLE
Feat/#83: exp history api 연동

### DIFF
--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -34,12 +34,28 @@ export async function getExpHistory(
   year: number,
   month: number
 ): Promise<ExpHisoryResponse> {
-  const params = new URLSearchParams({
-    year: year.toString(),
-    month: month.toString(),
-  });
-  const res = await API.get<ExpHisoryResponse>(
-    `/api/dashboard/history?${params}`
+  const months = [
+    { year: year, month: month - 1 },
+    { year: year, month },
+    { year: year, month: month + 1 },
+  ];
+
+  const res = await Promise.all(
+    months.map(({ year, month }) =>
+      API.get<ExpHisoryResponse>(
+        `/api/dashboard/history?${new URLSearchParams({
+          year: year.toString(),
+          month: month.toString(),
+        })}`
+      )
+    )
   );
-  return res.data;
+
+  return {
+    httpStatus: res[0].data.httpStatus,
+    message: res[0].data.message,
+    data: {
+      dateCounts: res.flatMap(res => res.data.data.dateCounts),
+    },
+  };
 }

--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import API from './config';
 
 export type JobRatioType = Record<string, number>;
@@ -10,12 +12,12 @@ export interface JobRatioResponse {
   };
 }
 
-type DateCount = {
+export type DateCount = {
   date: string;
   count: number;
 };
 
-type ExpHisoryResponse = {
+export type ExpHisoryResponse = {
   httpStatus: number;
   message: string;
   data: {

--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -1,6 +1,6 @@
 import API from './config';
 
-type JobRatioType = Record<string, number>;
+export type JobRatioType = Record<string, number>;
 
 export interface JobRatioResponse {
   httpStatus: number;
@@ -10,7 +10,34 @@ export interface JobRatioResponse {
   };
 }
 
+type DateCount = {
+  date: string;
+  count: number;
+};
+
+type ExpHisoryResponse = {
+  httpStatus: number;
+  message: string;
+  data: {
+    dateCounts: DateCount[];
+  };
+};
+
 export async function getJobRatio(): Promise<JobRatioResponse> {
   const res = await API.get<JobRatioResponse>('/api/dashboard/ratio');
+  return res.data;
+}
+
+export async function getExpHistory(
+  year: number,
+  month: number
+): Promise<ExpHisoryResponse> {
+  const params = new URLSearchParams({
+    year: year.toString(),
+    month: month.toString(),
+  });
+  const res = await API.get<ExpHisoryResponse>(
+    `/api/dashboard/history?${params}`
+  );
   return res.data;
 }

--- a/app/(main)/dashboard/components/ExpHistory.tsx
+++ b/app/(main)/dashboard/components/ExpHistory.tsx
@@ -3,24 +3,22 @@
 import React from 'react';
 import Calendar from '@/app/components/commons/Calendar';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
+import { ExpHisoryResponse } from '@/apis/dashboard';
 
-const MARKED_DATES = {
-  '2025-05-04': 1,
-  '2025-05-13': 2,
-  '2025-05-18': 1,
-  '2025-05-19': 2,
-  '2025-05-24': 1,
-  '2025-05-25': 2,
-} as const;
+export default function ExpHistory({
+  expHistory,
+}: {
+  expHistory: ExpHisoryResponse;
+}) {
+  const dateCounts = expHistory.data.dateCounts;
 
-export default function ExpHistory() {
   return (
     <>
       <div className="flex mb-6">
         <span className="body-23-b mr-2">경험 히스토리</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
-      <Calendar markedDates={MARKED_DATES} />
+      <Calendar markedDates={dateCounts} />
     </>
   );
 }

--- a/app/(main)/dashboard/components/ExpHistory.tsx
+++ b/app/(main)/dashboard/components/ExpHistory.tsx
@@ -18,7 +18,7 @@ export default function ExpHistory({
         <span className="body-23-b mr-2">경험 히스토리</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
-      <Calendar markedDates={dateCounts} />
+      <Calendar dateCounts={dateCounts} />
     </>
   );
 }

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -3,10 +3,15 @@ import ExpHistory from './components/ExpHistory';
 import Scrap from './components/Scrap';
 import ExpTimeLine from './components/ExpTimeLine';
 import ChartContainer from './components/ChartContainer';
-import { getJobRatio } from '@/apis/dashboard';
+import { getJobRatio, getExpHistory } from '@/apis/dashboard';
 
 export default async function DashboardPage() {
   const jobRatio = await getJobRatio();
+  const expHistory = await getExpHistory(
+    new Date().getFullYear(),
+    new Date().getMonth() + 1
+  );
+  console.log(new Date().getMonth());
 
   return (
     <div className="min-h-screen py-6 px-14">
@@ -19,7 +24,7 @@ export default async function DashboardPage() {
 
           {/* 경험 히스토리 */}
           <div className="grow-3 bg-gray-800 rounded-[23px] py-8 px-10">
-            <ExpHistory />
+            <ExpHistory expHistory={expHistory} />
           </div>
 
           {/* 스크랩 리스트 */}

--- a/app/components/commons/Calendar.tsx
+++ b/app/components/commons/Calendar.tsx
@@ -1,17 +1,32 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useCalendar } from '@/hooks/useCalendar';
 import CalendarHeader from './CalendarHeader';
 import CalendarDays from './CalendarDays';
-import { DateCount } from '@/apis/dashboard';
+import { DateCount, getExpHistory } from '@/apis/dashboard';
 
 interface CalendarProps {
-  markedDates?: DateCount[];
+  dateCounts?: DateCount[];
 }
 
-export default function Calendar({ markedDates = [] }: CalendarProps) {
+export default function Calendar({ dateCounts = [] }: CalendarProps) {
   const { year, month, monthName, moveMonth, calendarDays } = useCalendar();
+
+  const [markedDates, setMarkedDates] = useState<DateCount[]>(dateCounts);
+
+  useEffect(() => {
+    async function fetchMarkedDates() {
+      try {
+        const res = await getExpHistory(year, month + 1);
+        setMarkedDates(res.data.dateCounts);
+      } catch (error) {
+        console.error('경험 히스토리 불러오기 실패:', error);
+      }
+    }
+
+    fetchMarkedDates();
+  }, [year, month]);
 
   return (
     <>

--- a/app/components/commons/Calendar.tsx
+++ b/app/components/commons/Calendar.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import { useCalendar } from '@/hooks/useCalendar';
 import CalendarHeader from './CalendarHeader';
 import CalendarDays from './CalendarDays';
+import { DateCount } from '@/apis/dashboard';
 
 interface CalendarProps {
-  markedDates?: Record<string, number>;
+  markedDates?: DateCount[];
 }
 
-export default function Calendar({ markedDates = {} }: CalendarProps) {
+export default function Calendar({ markedDates = [] }: CalendarProps) {
   const { year, month, monthName, moveMonth, calendarDays } = useCalendar();
 
   return (

--- a/app/components/commons/CalendarDays.tsx
+++ b/app/components/commons/CalendarDays.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import DateMark from './DateMark';
 import { WEEK_DAYS } from '@/constants/calendar';
+import { DateCount } from '@/apis/dashboard';
 
 interface CalendarDaysProps {
   calendarDays: (number | null)[];
-  markedDates: Record<string, number>;
+  markedDates: DateCount[];
   year: number;
   month: number;
 }
@@ -31,7 +32,7 @@ export default function CalendarDays({
         {calendarDays.map((day, i) => {
           if (day === null) return <div key={i} />;
           const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-          const count = markedDates[dateStr];
+          const count = markedDates.find(d => d.date === dateStr)?.count;
           return (
             <div
               key={i}


### PR DESCRIPTION
## 📌 연관된 이슈

- close #83
- 
## 📝작업 내용

useEffect로 월 변경 버튼이 클릭 될 때 마다 데이터를 새로 fetch해오니까 렌더링이 너무 느려서 Promise.all로 이전달과 다음달 데이터를 함께 받아서 렌더링하도록 해뒀습니다. 백엔드에 api 수정 요청했고 반영해주시면 그 때 Promise.all 제거하도록 다시 변경하겠습니다

근데 그렇게 해도 빠르게 누르면 캘린더에서 렌더링되는데 딜레이가 조금 되는 것 같아서.. 추후 캘린더 컴포넌트 자체를 이전달,이번달,다음달 3개를 미리 렌더링해두고 변경하는 식으로 수정하겠습니다!

### 스크린샷 (선택)

https://github.com/user-attachments/assets/6e3dc6be-472f-42c0-93e3-06e453007e45

## 💬리뷰 요구사항
