### PR TITLE
Feat/#98/경험 상세 페이지 삭제 추가

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -49,6 +49,11 @@ interface GetExpByIdResponse {
   data: ExpPayload;
 }
 
+interface DeleteExpResponse {
+  httpStatus: number;
+  message: string;
+}
+
 export async function saveExp(payload: ExpPayload): Promise<SaveExpResponse> {
   const res = await API.post<SaveExpResponse>('/api/exp', {
     ...payload,
@@ -86,7 +91,7 @@ export async function getMyExp(): Promise<GetExpResponse> {
   return res.data;
 }
 
-export async function deleteExp(id: number) {
-  const res = await API.delete(`/api/exp/${id}`);
+export async function deleteExp(exp_id: number): Promise<DeleteExpResponse> {
+  const res = await API.delete(`/api/exp/${exp_id}`);
   return res.data;
 }

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -169,7 +169,7 @@ export default function ExpForm({ data }: ExpFormProps) {
 
   return (
     <form onSubmit={handleSubmit} className="p-20">
-      <div className="flex items-center justify-between w-full">
+      <div className="flex justify-between w-full">
         <div className="flex items-center">
           <button
             type="button"

--- a/app/(main)/exp/[id]/page.tsx
+++ b/app/(main)/exp/[id]/page.tsx
@@ -2,17 +2,18 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { ExpPayload, getExpById } from '@/apis/exp';
+import { ExpPayload, getExpById, deleteExp, editExp } from '@/apis/exp';
 import { EXP_OPTIONS } from '@/constants/expOptions';
-import { deleteExp } from '@/apis/exp';
 import { useRouter } from 'next/navigation';
 import Popup from '@/app/components/Popup';
+import BackIcon from '@/public/icons/Chevron_Left.svg';
 
 export default function ExpDetailPage() {
   const params = useParams();
   const router = useRouter();
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [editData, setEditData] = useState<ExpPayload>({} as ExpPayload);
   const [data, setData] = useState<ExpPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -27,6 +28,7 @@ export default function ExpDetailPage() {
       try {
         const res = await getExpById(expId);
         setData(res.data);
+        setEditData(res.data);
       } catch {
         setError('경험 데이터를 불러오는 데 실패했습니다.');
       }
@@ -106,9 +108,19 @@ export default function ExpDetailPage() {
   };
 
   return (
-    <main className="min-h-screen py-13 px-20 bg-black text-white">
-      <div className="flex justify-between">
-        <h1 className="text-3xl font-bold mb-[26px]">경험 상세</h1>
+    <div className="p-20">
+      <div className="flex justify-between w-full">
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={() => {
+              router.push('/exp');
+            }}
+          >
+            <BackIcon className="stroke-gray-50 w-[35px] h-[35px]" />
+          </button>
+          <div className="text-3xl font-bold">경험 상세</div>
+        </div>
         <div className="flex items-center gap-[9px]">
           <button
             type="button"
@@ -134,7 +146,9 @@ export default function ExpDetailPage() {
           )}
           <button
             type="button"
-            onClick={() => {}}
+            onClick={async () => {
+              await editExp(Number(params?.id), editData);
+            }}
             className="w-20 py-3 bg-primary-50 text-sm text-gray-1100 font-semibold rounded-lg"
           >
             수정
@@ -168,6 +182,6 @@ export default function ExpDetailPage() {
           </div>
         )}
       </section>
-    </main>
+    </div>
   );
 }

--- a/app/(main)/exp/[id]/page.tsx
+++ b/app/(main)/exp/[id]/page.tsx
@@ -4,11 +4,16 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { ExpPayload, getExpById } from '@/apis/exp';
 import { EXP_OPTIONS } from '@/constants/expOptions';
+import { deleteExp } from '@/apis/exp';
+import { useRouter } from 'next/navigation';
+import Popup from '@/app/components/Popup';
 
 export default function ExpDetailPage() {
   const params = useParams();
-  const [data, setData] = useState<ExpPayload | null>(null);
+  const router = useRouter();
 
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [data, setData] = useState<ExpPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -102,7 +107,40 @@ export default function ExpDetailPage() {
 
   return (
     <main className="min-h-screen py-13 px-20 bg-black text-white">
-      <h1 className="text-3xl font-bold mb-[26px]">경험 상세</h1>
+      <div className="flex justify-between">
+        <h1 className="text-3xl font-bold mb-[26px]">경험 상세</h1>
+        <div className="flex items-center gap-[9px]">
+          <button
+            type="button"
+            onClick={async () => {
+              setIsPopupOpen(true);
+            }}
+            className="w-20 py-3 bg-gray-1000 text-sm text-gray-300 font-semibold border border-gray-50-20 rounded-lg"
+          >
+            삭제
+          </button>
+          {isPopupOpen && (
+            <Popup
+              title="경험 삭제"
+              content={`경험을 삭제하시겠습니까?\n삭제하시면 다시 복구할 수 없습니다.`}
+              confirmText="삭제"
+              cancelText="취소"
+              onConfirm={async () => {
+                await deleteExp(Number(params?.id));
+                router.push('/exp');
+              }}
+              onCancel={() => setIsPopupOpen(false)}
+            />
+          )}
+          <button
+            type="button"
+            onClick={() => {}}
+            className="w-20 py-3 bg-primary-50 text-sm text-gray-1100 font-semibold rounded-lg"
+          >
+            수정
+          </button>
+        </div>
+      </div>
 
       <section className="bg-gray-800 p-8 rounded-[14px] text-gray-100">
         <h2 className="text-[21px] font-semibold mb-6 text-gray-50">내용</h2>

--- a/app/(main)/exp/[id]/page.tsx
+++ b/app/(main)/exp/[id]/page.tsx
@@ -144,29 +144,29 @@ export default function ExpDetailPage() {
 
       <section className="bg-gray-800 p-8 rounded-[14px] text-gray-100">
         <h2 className="text-[21px] font-semibold mb-6 text-gray-50">내용</h2>
-
         <div className="bg-gray-700 p-6 rounded-[4px] space-y-4 border border-gray-600 leading-relaxed">
           <p>경험 유형: {experienceLabel}</p>
           {renderDetailContent()}
         </div>
-
-        <div className="mt-10">
-          <h3 className="text-[21px] font-semibold mb-6 text-gray-50">
-            키워드
-          </h3>
-          <div className="bg-gray-700 p-3 rounded-[4px] border border-gray-600">
-            <div className="flex flex-wrap gap-2">
-              {data.keywords?.map((keyword: string, idx: number) => (
-                <span
-                  key={idx}
-                  className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100"
-                >
-                  #{keyword}
-                </span>
-              ))}
+        {!['수상', '자격증'].includes(experienceLabel) && (
+          <div className="mt-10">
+            <h3 className="text-[21px] font-semibold mb-6 text-gray-50">
+              키워드
+            </h3>
+            <div className="bg-gray-700 p-3 rounded-[4px] border border-gray-600">
+              <div className="flex flex-wrap gap-2">
+                {data.keywords?.map((keyword: string, idx: number) => (
+                  <span
+                    key={idx}
+                    className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100"
+                  >
+                    #{keyword}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </section>
     </main>
   );


### PR DESCRIPTION
## 📌 연관된 이슈

- close #98 

## 📝작업 내용

- 삭제/수정 버튼 추가
- 경험 삭제 API 연동
- 수상/자격증 상세 페이지 keyword 부분 삭제
- 경험 상세 페이지 뒤로 가기 추가 (-> 경험 메인 페이지로 이동) 

### 스크린샷 (선택)

## 💬리뷰 요구사항
