### PR TITLE
Codereview PR

### DIFF
--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -25,6 +25,8 @@ export interface ExpHisoryResponse {
   };
 }
 
+// 직무 비율을 가져오는 API 함수
+// API 호출 시 try-catch로 에러 처리를 하고, 에러 발생 시 null을 반환
 export async function getJobRatio(): Promise<JobRatioResponse | null> {
   try {
     const res = await API.get<JobRatioResponse>('/api/dashboard/ratio');
@@ -34,6 +36,7 @@ export async function getJobRatio(): Promise<JobRatioResponse | null> {
     return null;
   }
 }
+//
 
 export async function getExpHistory(
   year: number,

--- a/app/(main)/addExp/components/AwardForm.tsx
+++ b/app/(main)/addExp/components/AwardForm.tsx
@@ -11,11 +11,13 @@ interface AwardFormProps {
   onChange: (key: string, value: string) => void;
 }
 
+// ExpForm 컴포넌트에서 렌더링한 자격증 및 수상 form 컴포넌트
 export default function AwardForm({
   experienceType,
   data,
   onChange,
 }: AwardFormProps) {
+  // 초기 폼 상태 설정
   const [form, setForm] = useState({
     qualification: data?.qualification || '',
     publisher: data?.publisher || '',
@@ -23,11 +25,14 @@ export default function AwardForm({
     simpleDescription: data?.simpleDescription || '',
   });
 
+  // 폼의 각 필드 변경을 처리하는 함수
+  // key: 변경된 필드의 이름, value: 변경된 값
   const handleChange = (key: keyof typeof form, value: string) => {
     setForm(prev => ({
       ...prev,
       [key]: value,
     }));
+    // props로 전달받은 onChange 함수를 실행시켜 부모 컴포넌트에 변경된 값을 전달
     onChange(key, value);
   };
 
@@ -36,12 +41,14 @@ export default function AwardForm({
       <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%] pt-10">
         {experienceType === 'CERTIFICATES' ? '자격증명' : '수상명'}
       </div>
+      {/* 자격증명/수상명명 입력 박스, props로 onChange 함수를 전달함 */}
       <ExpInputBox
         type="string"
         placeholder={experienceType === 'CERTIFICATES' ? '자격증명' : '수상명'}
         value={form.qualification}
         onChange={e => handleChange('qualification', e.target.value)}
       />
+      {/* */}
 
       <div className="py-10">
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -48,6 +48,7 @@ const getInitialForm = (data?: ExpPayload & { selectedTab?: string }) => ({
   id: data?.id,
 });
 
+//최상위 ExpForm 컴포넌트
 export default function ExpForm({ data }: ExpFormProps) {
   const router = useRouter();
   const [isPopupOpen, setIsPopupOpen] = useState(false);
@@ -57,6 +58,7 @@ export default function ExpForm({ data }: ExpFormProps) {
     null
   );
 
+  //form 상태를 ExpForm에 저장
   const [form, setForm] = useState(getInitialForm(data));
   const [tab, setTab] = useState<'star' | 'simple'>('star');
 
@@ -124,6 +126,7 @@ export default function ExpForm({ data }: ExpFormProps) {
     }
   };
 
+  //상태 변화 동기화를 위한 handleChange 함수
   const handleChange = (key: string, value: string | string[]) => {
     setForm(prev => ({
       ...prev,
@@ -155,6 +158,7 @@ export default function ExpForm({ data }: ExpFormProps) {
   };
 
   const renderForm = () => {
+    // 자격증, 수상 form 컴포넌트 렌더링
     if (
       form.experienceType === 'CERTIFICATES' ||
       form.experienceType === 'PRIZE'
@@ -166,9 +170,12 @@ export default function ExpForm({ data }: ExpFormProps) {
         />
       );
     }
+    // STAR 양식과 간결 양식에 따라 다른 컴포넌트 렌더링
     if (form.formType === 'STAR_FORM') {
+      // onChange prop을 통해 상태 변화 동기화
       return <StarForm onChange={handleChange} />;
     }
+    // onChange prop을 통해 상태 변화 동기화
     return <SimpleForm onChange={handleChange} />;
   };
 

--- a/app/(main)/addExp/components/SimpleForm.tsx
+++ b/app/(main)/addExp/components/SimpleForm.tsx
@@ -11,7 +11,9 @@ interface SimpleFormProps {
   onChange: (key: string, value: string | string[]) => void;
 }
 
+// ExpForm 컴포넌트에서 렌더링한 SimpleForm 컴포넌트
 export default function SimpleForm({ data, onChange }: SimpleFormProps) {
+  // 초기 폼 상태 설정
   const [form, setForm] = useState({
     title: data?.title || '',
     startDate: String(data?.startDate) || '',
@@ -22,11 +24,14 @@ export default function SimpleForm({ data, onChange }: SimpleFormProps) {
     keywords: data?.keywords || [],
   });
 
+  // 폼의 각 필드 변경을 처리하는 함수
+  // key: 변경된 필드의 이름, value: 변경된 값
   const handleChange = (key: keyof typeof form, value: string | string[]) => {
     setForm(prev => ({
       ...prev,
       [key]: value,
     }));
+    // props로 전달받은 onChange 함수를 실행시켜 부모 컴포넌트에 변경된 값을 전달
     onChange(key, value);
   };
 
@@ -35,18 +40,21 @@ export default function SimpleForm({ data, onChange }: SimpleFormProps) {
       <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%] pt-10">
         제목
       </div>
+      {/* 경험 제목 입력 박스, props로 onChange 함수를 전달함 */}
       <ExpInputBox
         type="string"
         placeholder="경험 제목"
         value={form.title}
         onChange={e => handleChange('title', e.target.value)}
       />
+      {/* */}
 
       <div className="py-10">
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
           기간
         </div>
         <div className="flex gap-4">
+          {/* 기간 입력 박스, props로 onChange 함수를 전달함 */}
           <ExpInputBox
             type="date"
             value={form.startDate}
@@ -59,6 +67,7 @@ export default function SimpleForm({ data, onChange }: SimpleFormProps) {
             min={form.startDate}
             onChange={e => handleChange('endDate', e.target.value)}
           />
+          {/* */}
         </div>
       </div>
 
@@ -93,10 +102,12 @@ export default function SimpleForm({ data, onChange }: SimpleFormProps) {
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
           키워드
         </div>
+        {/* 키워드 입력 박스, props로 onChange 함수를 전달함 */}
         <KeywordInput
           value={form.keywords}
           onChange={newTags => handleChange('keywords', newTags)}
         />
+        {/* */}
       </div>
     </div>
   );

--- a/app/(main)/addExp/components/StarForm.tsx
+++ b/app/(main)/addExp/components/StarForm.tsx
@@ -11,7 +11,9 @@ interface StarFormProps {
   onChange: (key: string, value: string | string[]) => void;
 }
 
+// ExpForm 컴포넌트에서 렌더링한 StarForm 컴포넌트
 export default function StarForm({ data, onChange }: StarFormProps) {
+  // 초기 폼 상태 설정
   const [form, setForm] = useState({
     title: data?.title || '',
     startDate: String(data?.startDate) || '',
@@ -24,11 +26,14 @@ export default function StarForm({ data, onChange }: StarFormProps) {
     keywords: data?.keywords || [],
   });
 
+  // 폼의 각 필드 변경을 처리하는 함수 (simpleForm과 동일)
+  // key: 변경된 필드의 이름, value: 변경된 값
   const handleChange = (key: keyof typeof form, value: string | string[]) => {
     setForm(prev => ({
       ...prev,
       [key]: value,
     }));
+    // props로 전달받은 onChange 함수를 실행시켜 부모 컴포넌트에 변경된 값을 전달
     onChange(key, value);
   };
 
@@ -37,18 +42,21 @@ export default function StarForm({ data, onChange }: StarFormProps) {
       <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%] pt-10">
         제목
       </div>
+      {/* 경험 제목 입력 박스, props로 onChange 함수를 전달함 */}
       <ExpInputBox
         type="string"
         placeholder="경험 제목"
         value={form.title}
         onChange={e => handleChange('title', e.target.value)}
       />
+      {/* */}
 
       <div className="py-10">
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
           기간
         </div>
         <div className="flex gap-4">
+          {/* 기간 입력 박스, props로 onChange 함수를 전달함 */}
           <ExpInputBox
             type="date"
             value={form.startDate}
@@ -61,6 +69,7 @@ export default function StarForm({ data, onChange }: StarFormProps) {
             min={form.startDate}
             onChange={e => handleChange('endDate', e.target.value)}
           />
+          {/* */}
         </div>
       </div>
 
@@ -117,10 +126,12 @@ export default function StarForm({ data, onChange }: StarFormProps) {
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
           키워드
         </div>
+        {/* 키워드 입력 박스, props로 onChange 함수를 전달함 */}
         <KeywordInput
           value={form.keywords}
           onChange={newTags => handleChange('keywords', newTags)}
         />
+        {/* */}
       </div>
     </div>
   );

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { getJobRatio, getExpHistory } from '@/apis/dashboard';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import Footer from '@/app/components/Footer';
 
+//getJobRatio()로 API 호출
 export default async function DashboardPage() {
   const jobRatio = await getJobRatio();
   const expHistory = await getExpHistory(
@@ -29,10 +30,11 @@ export default async function DashboardPage() {
           </div>
         </div>
 
-        {/*null 체크 후 렌더링 */}
+        {/*getJobRatio()에서 API 호출 시 null이 반환되지 않았을 때만 하위 컴포넌트 렌더링 */}
         {jobRatio?.data?.ratios ? (
           <ChartContainer jobRatio={jobRatio} />
         ) : (
+          // jobRatio가 null이거나 비어있을 때 대체 UI
           <div className="flex flex-wrap gap-4 h-[319px]">
             <div className="flex-grow-4 bg-gray-800 rounded-[23px] py-8 px-10 flex flex-col">
               <div className="flex mb-3">


### PR DESCRIPTION
## 📌 연관된 PR

- https://github.com/Xpact-2025/FE/pull/77
- https://github.com/Xpact-2025/FE/pull/86

## 📝작업 내용

- 경험 입력 페이지 컴포넌트 생성 및 분리
- 대시보드 에러 처리

## 💬리뷰 요구사항

**1. 경험 입력 페이지 컴포넌트 생성 및 분리 시 props drilling, 상태 관리 문제 **
```tsx
//최상위 ExpForm 컴포넌트
export default function ExpForm({ data }: ExpFormProps) {
 //form 상태를 ExpForm에 저장
  const [form, setForm] = useState(getInitialForm(data));
//상태 변화 동기화를 위한 handleChange 함수
  const handleChange = (key: string, value: string | string[]) => {
      setForm(prev => ({
        ...prev,
        [key]: value,
      }));
    };
...
//handleChange함수를 props로 넘김
   if (form.formType === 'STAR_FORM') {
        return <StarForm onChange={handleChange} />;
      }
      return <SimpleForm onChange={handleChange} />;
```

```tsx
//경험 수정 시 기존 데이터를 불러오기 위해 data props를 받아 form에 세팅
export default function SimpleForm({ data, onChange }: SimpleFormProps) {
  const [form, setForm] = useState({
    title: data?.title || '',
    startDate: String(data?.startDate) || '',
    endDate: String(data?.endDate) || '',
    role: data?.role || '',
    perform: data?.perform || '',
    files: data?.files || '',
    keywords: data?.keywords || '',
  });
//컴포넌트의 상태가 변경될 경우 onChange 함수를 실행시켜 상위 컴포넌트의 상태도 변경 가능하도록 함
  const handleChange = (key: keyof typeof form, value: string) => {
    setForm(prev => ({
      ...prev,
      [key]: value,
    }));
    onChange(key, value);
  };

  return (
    <div>
      <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%] pt-10">
        제목
      </div>
//제목 입력, 파일 첨부 등의 컴포넌트를 분리하고 다시 onChange 함수를 props로 전달
      <ExpInputBox
        type="string"
        placeholder="경험 제목"
        value={form.title}
        onChange={e => handleChange('title', e.target.value)}
      />
   ...
```

현 상황: 
- page.tsx에서 폼 전체를 ExpForm 컴포넌트로 분리하고, 그 안에 AwardForm, FileInput, FormTab 등 하위 컴포넌트로 구성
- ExpForm에서 useState로 폼 데이터를 관리하며, 하위 컴포넌트에는 onChange 함수를 props로 전달

문제점: 
- 양식이 추가되며 컴포넌트가 깊어지고 props로 onChange를 계속 넘겨야 해서 구조가 복잡해짐
![image](https://github.com/user-attachments/assets/579e98f2-680b-47a9-bfbf-e615cacd7e48)

고민: 
- 각 컴포넌트마다 onChange를 넘기는 방식 외에 더 깔끔하고 유지보수에 유리한 구조가 있는지 고민이 됩니다.

**2. 프론트엔드에서의 API 연동 시 에러 처리 방식**
```tsx
export async function getJobRatio(): Promise<JobRatioResponse | null> {
  try {
    const res = await API.get<JobRatioResponse>('/api/dashboard/ratio');
    return res.data;
  } catch (error) {
    console.error('직무 비율 불러오기 실패:', error);
    return null;
  }
}
```
```tsx
export default async function DashboardPage() {
  const jobRatio = await getJobRatio();

  return (
    <div className="min-h-screen py-6 px-14">
   
          {jobRatio?.data ? (
              <ChartContainer jobRatio={jobRatio} />
          ) : (//데이터가 없을 경우 컴포넌트)
```

현 상황:
- 대시보드에서 사용하는 API 요청 함수들을 컴포넌트 외부 파일로 분리하고, 각 함수 내부에서 try-catch로 에러를 처리한 뒤, 실패 시 null을 반환하는 방식으로 구성

문제점: 
- 에러 원인에 따라 세부적인 처리가 어려움

고민: 
- 에러 핸들링을 API 함수에서 처리하는 게 나은지, 컴포넌트에서 try-catch로 직접 처리하는 게 나은지 고민이 됩니다.