### PR TITLE
Feat/#109: 레이아웃 변경 및 핵심스킬맵 더미데이터로 연동

### DIFF
--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -27,18 +27,27 @@ export interface ExpHisoryResponse {
 }
 
 export type CoreSkillMapType = {
-  name: string;
-  value: number;
+  coreSkillName: string;
+  score: number;
 };
 
 export interface CoreSkillMapResponse {
   httpStatus: number;
   message: string;
   data: {
-    coreSkillMaps: { coreSkillMaps: CoreSkillMapType[] };
-    strengthFeedback: string;
-    weaknessFeedback: string;
+    coreSkillMaps: CoreSkillMapType[];
+    strengthFeedback: {
+      strengthName: string;
+      reason: string;
+      careerSuggestion: string;
+    };
+    weaknessFeedback: {
+      weaknessName: string;
+      reason: string;
+      improvementSuggestion: string;
+    };
   };
+  success: boolean;
 }
 
 export async function getJobRatio(): Promise<JobRatioResponse | null> {
@@ -52,13 +61,45 @@ export async function getJobRatio(): Promise<JobRatioResponse | null> {
 }
 
 export async function getCoreSkillMap(): Promise<CoreSkillMapResponse | null> {
-  try {
-    const res = await API.post<CoreSkillMapResponse>('/api/dashboard/skills');
-    return res.data;
-  } catch (error) {
-    console.error('핵심 스킬맵 불러오기 실패:', error);
-    return null;
-  }
+  return {
+    httpStatus: 200,
+    message: 'success',
+    data: {
+      coreSkillMaps: [
+        {
+          coreSkillName: '서버사이드프로그래밍',
+          score: 8.5,
+        },
+        {
+          coreSkillName: '데이터베이스관리',
+          score: 7.2,
+        },
+        {
+          coreSkillName: 'API설계',
+          score: 7,
+        },
+        {
+          coreSkillName: '문제해결능력',
+          score: 9,
+        },
+        {
+          coreSkillName: '성능최적화',
+          score: 8.8,
+        },
+      ],
+      strengthFeedback: {
+        strengthName: '문제해결능력',
+        reason: '다양한 프로젝트를 통해 문제를 해결한 경험이 많아서',
+        careerSuggestion: '시스템 아키텍트 또는 기술 컨설턴트에 적합합니다.',
+      },
+      weaknessFeedback: {
+        weaknessName: 'API설계',
+        reason: 'API 설계 관련 직접적인 경험을 언급하지 않음',
+        improvementSuggestion: 'API 설계 공부 및 작은 프로젝트 참여',
+      },
+    },
+    success: true,
+  };
 }
 
 export async function getExpHistory(

--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -26,12 +26,37 @@ export interface ExpHisoryResponse {
   };
 }
 
+export type CoreSkillMapType = {
+  name: string;
+  value: number;
+};
+
+export interface CoreSkillMapResponse {
+  httpStatus: number;
+  message: string;
+  data: {
+    coreSkillMaps: { coreSkillMaps: CoreSkillMapType[] };
+    strengthFeedback: string;
+    weaknessFeedback: string;
+  };
+}
+
 export async function getJobRatio(): Promise<JobRatioResponse | null> {
   try {
     const res = await API.get<JobRatioResponse>('/api/dashboard/ratio');
     return res.data;
   } catch (error) {
     console.error('직무 비율 불러오기 실패:', error);
+    return null;
+  }
+}
+
+export async function getCoreSkillMap(): Promise<CoreSkillMapResponse | null> {
+  try {
+    const res = await API.post<CoreSkillMapResponse>('/api/dashboard/skills');
+    return res.data;
+  } catch (error) {
+    console.error('핵심 스킬맵 불러오기 실패:', error);
     return null;
   }
 }

--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -2,14 +2,15 @@
 
 import API from './config';
 
-export type JobRatioType = Record<string, number>;
+export type JobRatioType = {
+  name: string;
+  value: number;
+};
 
 export interface JobRatioResponse {
   httpStatus: number;
   message: string;
-  data: {
-    ratios: JobRatioType;
-  };
+  data: JobRatioType[];
 }
 
 export type DateCount = {

--- a/app/(main)/dashboard/components/ChartContainer.tsx
+++ b/app/(main)/dashboard/components/ChartContainer.tsx
@@ -13,7 +13,7 @@ export default function ChartContainer({
   const jobRatioData = jobRatio.data;
 
   return (
-    <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+    <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
       <div className="flex-[38] bg-gray-800 rounded-[23px] py-8 px-10 h-[270px]">
         <JobRatio jobRatioData={jobRatioData} />
       </div>

--- a/app/(main)/dashboard/components/ChartContainer.tsx
+++ b/app/(main)/dashboard/components/ChartContainer.tsx
@@ -10,7 +10,7 @@ export default function ChartContainer({
 }: {
   jobRatio: JobRatioResponse;
 }) {
-  const jobRatioData = jobRatio.data.ratios;
+  const jobRatioData = jobRatio.data;
 
   return (
     <div className="flex flex-wrap gap-4">

--- a/app/(main)/dashboard/components/ChartContainer.tsx
+++ b/app/(main)/dashboard/components/ChartContainer.tsx
@@ -3,14 +3,17 @@
 import dynamic from 'next/dynamic';
 const JobRatio = dynamic(() => import('./JobRatio'), { ssr: false });
 const SkillMap = dynamic(() => import('./SkillMap'), { ssr: false });
-import { JobRatioResponse } from '@/apis/dashboard';
+import { JobRatioResponse, CoreSkillMapResponse } from '@/apis/dashboard';
 
 export default function ChartContainer({
   jobRatio,
+  skillMap,
 }: {
   jobRatio: JobRatioResponse;
+  skillMap: CoreSkillMapResponse;
 }) {
   const jobRatioData = jobRatio.data;
+  const skillMapData = skillMap.data;
 
   return (
     <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
@@ -18,7 +21,7 @@ export default function ChartContainer({
         <JobRatio jobRatioData={jobRatioData} />
       </div>
       <div className="flex-[47] bg-gray-800 rounded-[23px] py-8 px-10 h-[270px]">
-        <SkillMap />
+        <SkillMap skillMapData={skillMapData} />
       </div>
     </div>
   );

--- a/app/(main)/dashboard/components/ChartContainer.tsx
+++ b/app/(main)/dashboard/components/ChartContainer.tsx
@@ -13,11 +13,11 @@ export default function ChartContainer({
   const jobRatioData = jobRatio.data;
 
   return (
-    <div className="flex flex-wrap gap-4">
-      <div className="flex-grow-4 bg-gray-800 rounded-[23px] py-8 px-10 h-[319px]">
+    <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+      <div className="flex-[38] bg-gray-800 rounded-[23px] py-8 px-10 h-[270px]">
         <JobRatio jobRatioData={jobRatioData} />
       </div>
-      <div className="flex-grow-6 bg-gray-800 rounded-[23px] py-8 px-10">
+      <div className="flex-[47] bg-gray-800 rounded-[23px] py-8 px-10 h-[270px]">
         <SkillMap />
       </div>
     </div>

--- a/app/(main)/dashboard/components/ExpHistory.tsx
+++ b/app/(main)/dashboard/components/ExpHistory.tsx
@@ -15,7 +15,7 @@ export default function ExpHistory({
   return (
     <>
       <div className="flex mb-6">
-        <span className="body-23-b mr-2">경험 히스토리</span>
+        <span className="body-16-sb mr-2">경험 히스토리</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
       <Calendar dateCounts={dateCounts} />

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -10,13 +10,13 @@ interface Experience {
 
 const sampleExperiences: Experience[] = [
   {
-    startDate: '2025-01-01',
+    startDate: '2025-03-01',
     endDate: '2025-06-30',
     title: '인턴십 A',
     experienceType: 'INTERN',
   },
   {
-    startDate: '2025-02-01',
+    startDate: '2025-03-01',
     endDate: '2025-03-10',
     title: '인턴십 B',
     experienceType: 'INTERN',
@@ -45,7 +45,7 @@ export default function ExpTimeLine() {
   return (
     <>
       <div className="flex mb-3">
-        <span className="body-23-b mr-2">경험 타임 라인</span>
+        <span className="body-16-sb mr-2">경험 타임 라인</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
       <Timeline experiences={sampleExperiences} />

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -48,7 +48,7 @@ export default function ExpTimeLine() {
         <span className="body-16-sb mr-2">경험 타임 라인</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
-      <Timeline experiences={sampleExperiences} />
+      <Timeline width={380} experiences={sampleExperiences} />
     </>
   );
 }

--- a/app/(main)/dashboard/components/JobRatio.tsx
+++ b/app/(main)/dashboard/components/JobRatio.tsx
@@ -49,7 +49,7 @@ export default function JobRatio({
               content={
                 <CustomLabel
                   job={data[0]?.name ?? ''}
-                  viewBox={{ cx: 109, cy: 109 }}
+                  viewBox={{ cx: 85, cy: 85 }}
                 />
               }
             />

--- a/app/(main)/dashboard/components/JobRatio.tsx
+++ b/app/(main)/dashboard/components/JobRatio.tsx
@@ -7,12 +7,9 @@ import { JobRatioType } from '@/apis/dashboard';
 export default function JobRatio({
   jobRatioData,
 }: {
-  jobRatioData: JobRatioType;
+  jobRatioData: JobRatioType[];
 }) {
-  const data = Object.entries(jobRatioData).map(([name, value]) => ({
-    name,
-    value,
-  }));
+  const data = jobRatioData;
 
   if (data.length === 0) {
     return (

--- a/app/(main)/dashboard/components/JobRatio.tsx
+++ b/app/(main)/dashboard/components/JobRatio.tsx
@@ -22,18 +22,18 @@ export default function JobRatio({
   return (
     <>
       <div className="flex mb-3">
-        <span className="body-23-b mr-2">직무 비율</span>
+        <span className="body-16-sb mr-2">직무 비율</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
       <div className="flex flex-row items-center justify-center">
         {/* 차트 */}
-        <PieChart width={218} height={218}>
+        <PieChart width={170} height={170}>
           <Pie
             data={data}
-            cx={109}
-            cy={109}
-            innerRadius={70}
-            outerRadius={100}
+            cx={85}
+            cy={85}
+            innerRadius={50}
+            outerRadius={70}
             fill="#FF6D01"
             dataKey="value"
             stroke="none"
@@ -65,7 +65,7 @@ export default function JobRatio({
                   className="inline-block w-4 h-4 rounded-full mr-3"
                   style={{ backgroundColor: COLORS[idx] }}
                 />
-                <span className="text-gray-300 body-16-r">
+                <span className="text-gray-300 body-12-m">
                   {item.name} {item.value}%
                 </span>
               </li>
@@ -95,7 +95,7 @@ function CustomLabel({
           y={cy - 10}
           textAnchor="middle"
           style={{
-            fontWeight: 500,
+            fontWeight: 400,
             fontSize: '14px',
             fill: '#A9A9A9',
             fontFamily: 'Pretendard',
@@ -108,8 +108,8 @@ function CustomLabel({
           y={cy + 20}
           textAnchor="middle"
           style={{
-            fontWeight: 700,
-            fontSize: '23px',
+            fontWeight: 600,
+            fontSize: '18px',
             fill: '#CDCDCD',
             fontFamily: 'Pretendard',
           }}

--- a/app/(main)/dashboard/components/JobRatio.tsx
+++ b/app/(main)/dashboard/components/JobRatio.tsx
@@ -37,7 +37,6 @@ export default function JobRatio({
             fill="#FF6D01"
             dataKey="value"
             stroke="none"
-            isAnimationActive={false}
           >
             {data.map((entry, index) => (
               <Cell

--- a/app/(main)/dashboard/components/ProfileCard.tsx
+++ b/app/(main)/dashboard/components/ProfileCard.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function ProfileCard() {
   return (
-    <div className="flex flex-col items-center justify-center p-2 h-[270px]">
+    <div className="flex flex-col items-center justify-center p-2 min-w-[120px] h-[270px]">
       <Image
         src="/images/profile.svg"
         alt="profile"

--- a/app/(main)/dashboard/components/ProfileCard.tsx
+++ b/app/(main)/dashboard/components/ProfileCard.tsx
@@ -1,30 +1,22 @@
 import Image from 'next/image';
-import BuildingIcon from '@/public/icons/Building.svg';
-import UserCardIdIcon from '@/public/icons/User_Card_ID.svg';
+
 export default function ProfileCard() {
   return (
-    <div className="flex flex-col items-center justify-center p-4 ">
+    <div className="flex flex-col items-center justify-center p-2 h-[270px]">
       <Image
         src="/images/profile.svg"
         alt="profile"
-        width={180}
-        height={180}
-        className="rounded-full my-4"
+        width={150}
+        height={150}
+        className="rounded-full my-3"
       />
-      <div className="px-4 py-1 mt-2 bg-primary rounded-full body-16-sb text-gray-1000">
+      <div className="px-4 py-1 bg-primary rounded-full body-12-m text-gray-1000">
         서비스 기획자
       </div>
-      <h2 className="mt-2 font-semibold text-[25px]">김잇타</h2>
-      <hr className="border-gray-700 border-[1.5] w-full my-6" />
-      <div className="font-body-16-r text-gray-300 stroke-gray-300 flex flex-col gap-[12px]">
-        <div className="mb-1 flex items-center gap-2">
-          <BuildingIcon />
-          잇타대학교 무슨학과<span className="body-12-m">졸업</span>
-        </div>
-        <div className="mb-2 flex items-center gap-2">
-          <UserCardIdIcon />
-          24세
-        </div>
+      <h2 className="my-2 body-16-sb">김잇타</h2>
+      <div className="body-9-r text-gray-300 stroke-gray-300 flex flex-col">
+        <span>잇타대학교 무슨학과</span>
+        <span>24세</span>
       </div>
     </div>
   );

--- a/app/(main)/dashboard/components/Scrap.tsx
+++ b/app/(main)/dashboard/components/Scrap.tsx
@@ -2,29 +2,29 @@ import HelpIcon from '@/public/icons/Circle_Help.svg';
 
 const scrapItems = [
   {
-    title: '현대자동차\n서비스 디자인 공모전',
+    title: '현대자동차 서비스 디자인 공모전',
     dday: 1,
   },
   {
-    title: '창의 혁신\n데이터 분석 공모전',
+    title: '창의 혁신 데이터 분석 공모전',
     dday: 3,
   },
   {
-    title: '[카카오뱅크]\n결제 서비스 기획 인턴',
+    title: '[카카오뱅크] 결제 서비스 기획 인턴',
     dday: 8,
   },
   {
-    title: '[토스]\nSales Mandgement 인턴',
+    title: '[토스] Sales Mandgement 인턴',
     dday: 11,
   },
 ];
 
 function ScrapCard({ title, dday }: { title: string; dday: number }) {
   return (
-    <div className="flex justify-between items-center bg-gray-700 border border-gray-50-20 rounded-[8px] px-[32px] py-[15px]">
-      <div className="body-16-sb text-gray-50 whitespace-pre-line">{title}</div>
+    <div className="flex justify-between items-center border-b border-gray-50-20 py-[10px]">
+      <div className="body-12-m text-gray-50 whitespace-pre-line">{title}</div>
       <div
-        className={`title-30-m ${dday <= 7 ? 'text-gray-50' : 'text-gray-500'}`}
+        className={`body-14-m ${dday <= 7 ? 'text-gray-50' : 'text-gray-500'}`}
       >
         D-{dday}
       </div>
@@ -36,7 +36,7 @@ export default function Scrap() {
   return (
     <>
       <div className="flex mb-6">
-        <span className="body-23-b mr-2">스크랩</span>
+        <span className="body-16-sb mr-2">스크랩</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
       <div className="flex flex-col gap-3">

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -46,7 +46,6 @@ export default function SkillMap() {
             stroke="#FF6D01"
             fill="#FF6D01"
             fillOpacity={0.2}
-            isAnimationActive={false}
           />
         </RadarChart>
         {/* 설명 */}

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -21,19 +21,18 @@ export default function SkillMap() {
   return (
     <>
       <div className="flex mb-3">
-        <span className="body-23-b mr-2">핵심 스킬 맵</span>
+        <span className="body-16-sb mr-2">핵심 스킬 맵</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
-      <div className="flex flex-row flex-wrap items-center justify-center">
+      <div className="flex flex-row items-center justify-center py-4">
         {/* 레이더 차트 */}
         <RadarChart
           width={350}
-          height={220}
+          height={150}
           cx="50%"
           cy="50%"
           outerRadius="80%"
           data={data}
-          className="mx-5"
         >
           <PolarGrid stroke="#444" />
           <PolarAngleAxis
@@ -53,17 +52,17 @@ export default function SkillMap() {
         {/* 설명 */}
         <div className="flex flex-col justify-center gap-4">
           <div>
-            <div className="text-gray-300 body-12-m mb-2">강점 역량</div>
+            <div className="text-gray-300 body-10-m mb-2">강점 역량</div>
             <div className="flex items-center">
               <span className="inline-block w-3 h-3 border-2 border-gray-200 rounded-2xl mr-2" />
-              <span className="text-primary body-16-sb">사용자 중심 사고</span>
+              <span className="text-primary body-12-m">사용자 중심 사고</span>
             </div>
           </div>
           <div>
-            <div className="text-gray-300 body-12-m mb-2">보완 필요 역량</div>
+            <div className="text-gray-300 body-10-m mb-2">보완 필요 역량</div>
             <div className="flex items-center">
               <span className="inline-block w-3 h-3 border-2 border-gray-200 rounded-2xl mr-2" />
-              <span className="text-primary body-16-sb">문제 해결력</span>
+              <span className="text-primary body-12-m">문제 해결력</span>
             </div>
           </div>
         </div>

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -16,12 +16,6 @@ export default function SkillMap({
   skillMapData: CoreSkillMapResponse['data'];
 }) {
   const { coreSkillMaps, strengthFeedback, weaknessFeedback } = skillMapData;
-  console.log(
-    'coreSkillMaps',
-    coreSkillMaps,
-    strengthFeedback,
-    weaknessFeedback
-  );
 
   return (
     <>
@@ -29,32 +23,54 @@ export default function SkillMap({
         <span className="body-16-sb mr-2">핵심 스킬 맵</span>
         <HelpIcon className="stroke-gray-600" />
       </div>
-      <div className="flex flex-row items-center justify-center py-4">
-        {/* 레이더 차트 */}
-        <RadarChart
-          width={350}
-          height={150}
-          cx="50%"
-          cy="50%"
-          outerRadius="80%"
-          data={coreSkillMaps}
+
+      <div className="mt-10 group flex w-full overflow-hidden relative h-[200px]">
+        {/* 차트 영역 */}
+        <div
+          className="
+            transition-all duration-500 
+            transform 
+            translate-x-0 
+            opacity-100 
+            group-hover:-translate-x-full 
+            group-hover:opacity-0
+            group-hover:absolute group-hover:left-0
+          "
         >
-          <PolarGrid stroke="#444" />
-          <PolarAngleAxis
-            dataKey="coreSkillName"
-            tick={{ fill: '#CDCDCD', fontSize: 13 }}
-          />
-          <PolarRadiusAxis axisLine={false} tick={false} stroke="#444" />
-          <Radar
-            name="역량"
-            dataKey="score"
-            stroke="#FF6D01"
-            fill="#FF6D01"
-            fillOpacity={0.2}
-          />
-        </RadarChart>
-        {/* 설명 */}
-        <div className="flex flex-col justify-center gap-4">
+          <RadarChart
+            width={300}
+            height={150}
+            cx="50%"
+            cy="50%"
+            outerRadius="80%"
+            data={coreSkillMaps}
+          >
+            <PolarGrid stroke="#444" />
+            <PolarAngleAxis
+              dataKey="coreSkillName"
+              tick={{ fill: '#CDCDCD', fontSize: 13 }}
+            />
+            <PolarRadiusAxis axisLine={false} tick={false} stroke="#444" />
+            <Radar
+              name="역량"
+              dataKey="score"
+              stroke="#FF6D01"
+              fill="#FF6D01"
+              fillOpacity={0.2}
+            />
+          </RadarChart>
+        </div>
+
+        {/* 설명 영역 */}
+        <div
+          className={`
+            pl-4 transition-all duration-500 
+            flex flex-col gap-4 
+            group-hover:justify-center
+            group-hover:-translate-x-full
+            group-hover:absolute group-hover:left-30
+          `}
+        >
           <div>
             <div className="text-gray-300 body-10-m mb-2">강점 역량</div>
             <div className="flex items-center">
@@ -72,6 +88,46 @@ export default function SkillMap({
                 {weaknessFeedback.weaknessName}
               </span>
             </div>
+          </div>
+        </div>
+        <div
+          className={`
+            w-2/3 transition-all duration-500
+            flex-col gap-4
+            hidden group-hover:block
+            group-hover:justify-right
+            group-hover:absolute group-hover:right-0
+          `}
+        >
+          <div
+            className="text-gray-500 body-11-m text-left
+              hidden group-hover:block
+              group-hover:text-center"
+          >
+            <p className="mb-2">
+              강점 이유:
+              <span className="text-gray-300 body-10-m">
+                {strengthFeedback.reason}
+              </span>
+            </p>
+            <p className="mb-2">
+              강점 커리어 제안:
+              <span className="text-gray-300 body-10-m">
+                {strengthFeedback.careerSuggestion}
+              </span>
+            </p>
+            <p className="mb-2">
+              보완 필요 이유:
+              <span className="text-gray-300 body-10-m">
+                {weaknessFeedback.reason}
+              </span>
+            </p>
+            <p className="mb-2">
+              보완 활동 제안:
+              <span className="text-gray-300 body-10-m">
+                {weaknessFeedback.improvementSuggestion}
+              </span>
+            </p>
           </div>
         </div>
       </div>

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CoreSkillMapResponse } from '@/apis/dashboard';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import {
   RadarChart,
@@ -9,15 +10,19 @@ import {
   PolarRadiusAxis,
 } from 'recharts';
 
-const data = [
-  { skill: '사용자 중심 사고', score: 90, fullMark: 100 },
-  { skill: '콘텐츠 기획력', score: 70, fullMark: 100 },
-  { skill: '데이터 분석', score: 80, fullMark: 100 },
-  { skill: '문제 해결력', score: 40, fullMark: 100 },
-  { skill: '커뮤니케이션', score: 70, fullMark: 100 },
-];
+export default function SkillMap({
+  skillMapData,
+}: {
+  skillMapData: CoreSkillMapResponse['data'];
+}) {
+  const { coreSkillMaps, strengthFeedback, weaknessFeedback } = skillMapData;
+  console.log(
+    'coreSkillMaps',
+    coreSkillMaps,
+    strengthFeedback,
+    weaknessFeedback
+  );
 
-export default function SkillMap() {
   return (
     <>
       <div className="flex mb-3">
@@ -32,11 +37,11 @@ export default function SkillMap() {
           cx="50%"
           cy="50%"
           outerRadius="80%"
-          data={data}
+          data={coreSkillMaps}
         >
           <PolarGrid stroke="#444" />
           <PolarAngleAxis
-            dataKey="skill"
+            dataKey="coreSkillName"
             tick={{ fill: '#CDCDCD', fontSize: 13 }}
           />
           <PolarRadiusAxis axisLine={false} tick={false} stroke="#444" />
@@ -54,14 +59,18 @@ export default function SkillMap() {
             <div className="text-gray-300 body-10-m mb-2">강점 역량</div>
             <div className="flex items-center">
               <span className="inline-block w-3 h-3 border-2 border-gray-200 rounded-2xl mr-2" />
-              <span className="text-primary body-12-m">사용자 중심 사고</span>
+              <span className="text-primary body-12-m">
+                {strengthFeedback.strengthName}
+              </span>
             </div>
           </div>
           <div>
             <div className="text-gray-300 body-10-m mb-2">보완 필요 역량</div>
             <div className="flex items-center">
               <span className="inline-block w-3 h-3 border-2 border-gray-200 rounded-2xl mr-2" />
-              <span className="text-primary body-12-m">문제 해결력</span>
+              <span className="text-primary body-12-m">
+                {weaknessFeedback.weaknessName}
+              </span>
             </div>
           </div>
         </div>

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -60,18 +60,6 @@ export default async function DashboardPage() {
             <Scrap />
           </div>
         </div>
-
-        {/* <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
-          <div className="grow-2 bg-gray-800 rounded-[23px] py-8 px-10">
-            <ExpTimeLine />
-          </div>
-          <div className="grow-1 bg-gray-800 rounded-[23px] py-8 px-10">
-            <ExpHistory expHistory={expHistory} />
-          </div>
-          <div className="grow-1 bg-gray-800 rounded-[23px] py-8 px-10">
-            <Scrap />
-          </div>
-        </div> */}
       </div>
       <Footer />
     </div>

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -30,7 +30,7 @@ export default async function DashboardPage() {
         </div>
 
         {/*null 체크 후 렌더링 */}
-        {jobRatio?.data?.ratios ? (
+        {jobRatio?.data ? (
           <ChartContainer jobRatio={jobRatio} />
         ) : (
           <div className="flex flex-wrap gap-4 h-[319px]">

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -3,7 +3,7 @@ import ExpHistory from './components/ExpHistory';
 import Scrap from './components/Scrap';
 import ExpTimeLine from './components/ExpTimeLine';
 import ChartContainer from './components/ChartContainer';
-import { getJobRatio, getExpHistory, getCoreSkillMap } from '@/apis/dashboard';
+import { getJobRatio, getExpHistory } from '@/apis/dashboard';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import Footer from '@/app/components/Footer';
 

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -17,47 +17,61 @@ export default async function DashboardPage() {
   return (
     <div className="min-h-screen py-6 px-14">
       <div className="flex flex-col gap-4">
-        <div className="flex flex-wrap 2xl:flex-nowrap gap-4 h-auto">
-          <div className="grow-2 bg-gray-800 rounded-[23px]">
+        <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+          <div className="flex-[1] bg-gray-800 rounded-[23px]">
             <ProfileCard />
           </div>
-          <div className="grow-3 bg-gray-800 rounded-[23px] py-8 px-10">
+          {jobRatio?.data ? (
+            <div className="flex-[7]">
+              <ChartContainer jobRatio={jobRatio} />
+            </div>
+          ) : (
+            <div className="flex-[7] flex flex-wrap grow-7 gap-4 h-[319px]">
+              <div className="flex-grow-38 bg-gray-800 rounded-[23px] py-8 px-10 flex flex-col">
+                <div className="flex mb-3">
+                  <span className="  mr-2">직무 비율</span>
+                  <HelpIcon className="stroke-gray-600" />
+                </div>
+                <div className="flex flex-1 items-center justify-center">
+                  경험 정보를 추가해주세요.
+                </div>
+              </div>
+              <div className="flex-grow-47 bg-gray-800 rounded-[23px] py-8 px-10 flex flex-col">
+                <div className="flex mb-3">
+                  <span className="body-16-sb mr-2">핵심 스킬맵</span>
+                  <HelpIcon className="stroke-gray-600" />
+                </div>
+                <div className="flex flex-1 items-center justify-center">
+                  경험 정보를 추가해주세요.
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+          <div className="flex-[2] bg-gray-800 rounded-[23px] py-8 px-10">
+            <ExpTimeLine />
+          </div>
+          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-10">
             <ExpHistory expHistory={expHistory} />
           </div>
-          <div className="grow-4 bg-gray-800 rounded-[23px] py-8 px-10">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-10">
             <Scrap />
           </div>
         </div>
 
-        {/*null 체크 후 렌더링 */}
-        {jobRatio?.data ? (
-          <ChartContainer jobRatio={jobRatio} />
-        ) : (
-          <div className="flex flex-wrap gap-4 h-[319px]">
-            <div className="flex-grow-4 bg-gray-800 rounded-[23px] py-8 px-10 flex flex-col">
-              <div className="flex mb-3">
-                <span className="body-23-b mr-2">직무 비율</span>
-                <HelpIcon className="stroke-gray-600" />
-              </div>
-              <div className="flex flex-1 items-center justify-center">
-                경험 정보를 추가해주세요.
-              </div>
-            </div>
-            <div className="flex-grow-6 bg-gray-800 rounded-[23px] py-8 px-10 flex flex-col">
-              <div className="flex mb-3">
-                <span className="body-23-b mr-2">핵심 스킬맵</span>
-                <HelpIcon className="stroke-gray-600" />
-              </div>
-              <div className="flex flex-1 items-center justify-center">
-                경험 정보를 추가해주세요.
-              </div>
-            </div>
+        {/* <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+          <div className="grow-2 bg-gray-800 rounded-[23px] py-8 px-10">
+            <ExpTimeLine />
           </div>
-        )}
-
-        <div className="bg-gray-800 rounded-[23px] py-8 px-10">
-          <ExpTimeLine />
-        </div>
+          <div className="grow-1 bg-gray-800 rounded-[23px] py-8 px-10">
+            <ExpHistory expHistory={expHistory} />
+          </div>
+          <div className="grow-1 bg-gray-800 rounded-[23px] py-8 px-10">
+            <Scrap />
+          </div>
+        </div> */}
       </div>
       <Footer />
     </div>

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -3,7 +3,7 @@ import ExpHistory from './components/ExpHistory';
 import Scrap from './components/Scrap';
 import ExpTimeLine from './components/ExpTimeLine';
 import ChartContainer from './components/ChartContainer';
-import { getJobRatio, getExpHistory } from '@/apis/dashboard';
+import { getJobRatio, getExpHistory, getCoreSkillMap } from '@/apis/dashboard';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import Footer from '@/app/components/Footer';
 

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -3,12 +3,13 @@ import ExpHistory from './components/ExpHistory';
 import Scrap from './components/Scrap';
 import ExpTimeLine from './components/ExpTimeLine';
 import ChartContainer from './components/ChartContainer';
-import { getJobRatio, getExpHistory } from '@/apis/dashboard';
+import { getJobRatio, getExpHistory, getCoreSkillMap } from '@/apis/dashboard';
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import Footer from '@/app/components/Footer';
 
 export default async function DashboardPage() {
   const jobRatio = await getJobRatio();
+  const skillMap = await getCoreSkillMap();
   const expHistory = await getExpHistory(
     new Date().getFullYear(),
     new Date().getMonth() + 1
@@ -21,9 +22,9 @@ export default async function DashboardPage() {
           <div className="flex-[1] bg-gray-800 rounded-[23px]">
             <ProfileCard />
           </div>
-          {jobRatio?.data ? (
+          {jobRatio && skillMap ? (
             <div className="flex-[7]">
-              <ChartContainer jobRatio={jobRatio} />
+              <ChartContainer jobRatio={jobRatio} skillMap={skillMap} />
             </div>
           ) : (
             <div className="flex-[7] flex flex-wrap grow-7 gap-4 h-[319px]">

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -17,7 +17,7 @@ export default async function DashboardPage() {
   return (
     <div className="min-h-screen py-6 px-14">
       <div className="flex flex-col gap-4">
-        <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+        <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
           <div className="flex-[1] bg-gray-800 rounded-[23px]">
             <ProfileCard />
           </div>
@@ -49,7 +49,7 @@ export default async function DashboardPage() {
           )}
         </div>
 
-        <div className="flex flex-grow flex-wrap xl:flex-nowrap gap-4 h-auto">
+        <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
           <div className="flex-[2] bg-gray-800 rounded-[23px] py-8 px-10">
             <ExpTimeLine />
           </div>

--- a/app/components/commons/BtnNext.tsx
+++ b/app/components/commons/BtnNext.tsx
@@ -4,7 +4,7 @@ interface BtnNextProps {
   moveNext: (direction: number) => void;
 }
 
-export default function BtnPrev({ moveNext }: BtnNextProps) {
+export default function BtnNext({ moveNext }: BtnNextProps) {
   return (
     <button
       onClick={() => moveNext(1)}

--- a/app/components/commons/BtnNext.tsx
+++ b/app/components/commons/BtnNext.tsx
@@ -8,10 +8,10 @@ export default function BtnPrev({ moveNext }: BtnNextProps) {
   return (
     <button
       onClick={() => moveNext(1)}
-      className="flex items-center justify-center bg-gray-700 rounded-lg w-9 h-9 cursor-pointer mx-1.5 hover:bg-gray-600 transition"
+      className="flex items-center justify-center bg-gray-700 rounded-lg w-[28px] h-[28px] cursor-pointer mx-1.5 hover:bg-gray-600 transition"
       aria-label="다음 달"
     >
-      <BackIcon className="stroke-gray-100 rotate-180" width={20} height={20} />
+      <BackIcon className="stroke-gray-100 rotate-180" width={15} height={15} />
     </button>
   );
 }

--- a/app/components/commons/BtnPrev.tsx
+++ b/app/components/commons/BtnPrev.tsx
@@ -9,10 +9,10 @@ export default function BtnPrev({ movePrev }: BtnPrevProps) {
     <button
       onClick={() => movePrev(-1)}
       type="button"
-      className="flex items-center justify-center bg-gray-700 rounded-lg w-9 h-9 cursor-pointer mx-1.5 hover:bg-gray-600 transition"
+      className="flex items-center justify-center bg-gray-700 rounded-lg w-[28px] h-[28px] cursor-pointer mx-1.5 hover:bg-gray-600 transition"
       aria-label="이전 달"
     >
-      <BackIcon className="stroke-gray-100 w-[20px] h-[20px]" />
+      <BackIcon className="stroke-gray-100" width={15} height={15} />
     </button>
   );
 }

--- a/app/components/commons/CalendarDays.tsx
+++ b/app/components/commons/CalendarDays.tsx
@@ -22,7 +22,7 @@ export default function CalendarDays({
         {WEEK_DAYS.map(day => (
           <div
             key={day}
-            className="text-center text-gray-100 body-16-r select-none"
+            className="text-center text-gray-100 body-12-r select-none"
           >
             {day}
           </div>
@@ -36,7 +36,7 @@ export default function CalendarDays({
           return (
             <div
               key={i}
-              className="text-center pt-2 h-[40px] text-gray-300 body-16-r relative select-none"
+              className="text-center pt-2 h-[40px] text-gray-300 body-11-m relative select-none"
             >
               {day}
               {count && <DateMark count={count} />}

--- a/app/components/commons/CalendarHeader.tsx
+++ b/app/components/commons/CalendarHeader.tsx
@@ -15,7 +15,7 @@ export default function CalendarHeader({
   return (
     <div className="flex items-center justify-between mb-6 mt-2">
       <BtnPrev movePrev={moveMonth} />
-      <span className="body-18-m text-gray-100 min-w-[120px] text-center">
+      <span className="body-12-m text-gray-100 text-center">
         {monthName} {year}
       </span>
       <BtnNext moveNext={moveMonth} />

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -122,7 +122,7 @@ export default function Timeline({
           {monthLabels.map(label => (
             <div
               key={label}
-              className="flex-1 min-w-0 py-2 flex items-center justify-center bg-gray-700 rounded-lg"
+              className="flex-1 min-w-0 py-2 flex items-center justify-center bg-gray-700 rounded-lg body-12-m"
             >
               {label}
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -239,6 +239,21 @@
   letter-spacing: var(--tracking-body-12-r);
 }
 
+.body-11-m {
+  font: var(--font-body-11-m);
+  letter-spacing: var(--tracking-body-11-m);
+}
+
+.body-10-m {
+  font: var(--font-body-10-m);
+  letter-spacing: var(--tracking-body-10-m);
+}
+
+.body-9-r {
+  font: var(--font-body-9-r);
+  letter-spacing: var(--tracking-body-9-r);
+}
+
 :root {
   --background: var(--color-gray-1000);
   --foreground: var(--color-gray-50);

--- a/app/globals.css
+++ b/app/globals.css
@@ -146,6 +146,15 @@
   --font-body-12-r: 300 12px/150% sans-serif;
   --tracking-body-12-r: 0em;
 
+  --font-body-11-m: 400 11px/150% sans-serif;
+  --tracking-body-11-m: 0em;
+
+  --font-body-10-m: 400 10px/150% sans-serif;
+  --tracking-body-10-m: 0em;
+
+  --font-body-9-r: 300 9px/150% sans-serif;
+  --tracking-body-9-r: 0em;
+
   /* Pretendard 폰트 */
   --font-pretendard: 'Pretendard Variable', sans-serif;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -96,54 +96,54 @@
   /* Type System */
 
   /* Headline */
-  --font-headline-60-m: 600 60px/130% sans-serif;
+  --font-headline-60-m: 500 60px/130% sans-serif;
   --tracking-headline-60-m: -0.04em;
 
   /* Title */
-  --font-title-40-m: 500 40px/150% sans-serif;
+  --font-title-40-m: 400 40px/150% sans-serif;
   --tracking-title-40-m: -0.02em;
 
-  --font-title-30-m: 500 30px/120% sans-serif;
+  --font-title-30-m: 400 30px/120% sans-serif;
   --tracking-title-30-m: 0em;
 
   /* Body */
-  --font-body-26-sb: 600 26px/104% sans-serif;
+  --font-body-26-sb: 500 26px/104% sans-serif;
   --tracking-body-26-sb: 0em;
 
-  --font-body-23-b: 700 23px/104% sans-serif;
+  --font-body-23-b: 600 23px/104% sans-serif;
   --tracking-body-23-b: 0em;
 
-  --font-body-20-sb: 600 20px/155% sans-serif;
+  --font-body-20-sb: 500 20px/155% sans-serif;
   --tracking-body-20-sb: -0.02em;
 
-  --font-body-20-r: 400 20px/155% sans-serif;
+  --font-body-20-r: 300 20px/155% sans-serif;
   --tracking-body-20-r: -0.02em;
 
-  --font-body-18-sb: 600 18px/170% sans-serif;
+  --font-body-18-sb: 500 18px/170% sans-serif;
   --tracking-body-18-sb: 0em;
 
-  --font-body-18-m: 500 18px/133% sans-serif;
+  --font-body-18-m: 400 18px/133% sans-serif;
   --tracking-body-18-m: 0em;
 
-  --font-body-18-r: 400 18px/140% sans-serif;
+  --font-body-18-r: 300 18px/140% sans-serif;
   --tracking-body-18-m: -0.03em;
 
-  --font-body-16-sb: 600 16px/150% sans-serif;
+  --font-body-16-sb: 500 16px/150% sans-serif;
   --tracking-body-16-sb: 0em;
 
-  --font-body-16-r: 400 16px/150% sans-serif;
+  --font-body-16-r: 300 16px/150% sans-serif;
   --tracking-body-16-r: 0em;
 
-  --font-body-14-sb: 600 14px/130% sans-serif;
+  --font-body-14-sb: 500 14px/130% sans-serif;
   --tracking-body-14-sb: 0.02em;
 
-  --font-body-14-m: 500 14px/171% sans-serif;
+  --font-body-14-m: 400 14px/171% sans-serif;
   --tracking-body-14-m: 0em;
 
-  --font-body-12-m: 500 12px/117% sans-serif;
+  --font-body-12-m: 400 12px/117% sans-serif;
   --tracking-body-12-m: -0.025em;
 
-  --font-body-12-r: 400 12px/150% sans-serif;
+  --font-body-12-r: 300 12px/150% sans-serif;
   --tracking-body-12-r: 0em;
 
   /* Pretendard 폰트 */


### PR DESCRIPTION
## 📌 연관된 이슈

- close #109

## 📝작업 내용

- 대시보드 레이아웃 변경
- font weight 한단계씩 하향
- 타입시스템 추가
- 핵심 스킬맵 api 연동하려고 했는데 api 수정이 필요하다고 하셔서 답변 형식 맞춰서 더미데이터 넣어서 구현만 했습니다

### 스크린샷 (선택)

https://github.com/user-attachments/assets/80dac87e-a4f5-4206-a660-fd85ff5a4d39

마우스 올리면 차트 사라지고 강점이랑 약점 보이게끔 애니메이션도 넣어봤는데 너무 어렵네요...............
애니메이션은 좀 더 수정해야할 것 같습니다 ㅜㅜ

## 💬리뷰 요구사항
