### PR TITLE
Feat/#116/exp api

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -5,23 +5,29 @@ import API from './config';
 
 export interface ExpPayload {
   id?: number;
-  status: ExpStatus;
   experienceType: ExpType;
-  formType?: ExpFormType;
-  uploadType?: UploadType;
   qualification?: string;
   publisher?: string;
-  issueDate?: Date;
-  simpleDescription?: string;
+  issueDate?: string;
   title?: string;
-  startDate?: Date;
-  endDate?: Date;
-  role?: string;
-  perform?: string;
+  startDate?: string;
+  endDate?: string;
+  subExperiences?: SubExperience[];
+}
+
+export interface SubExperience {
+  id?: number;
+  status: ExpStatus;
+  formType?: ExpFormType;
+  uploadType?: UploadType;
+  subTitle?: string;
   situation?: string;
   task?: string;
   action?: string;
   result?: string;
+  role?: string;
+  perform?: string;
+  simpleDescription?: string;
   files?: string[];
   keywords?: string[];
 }
@@ -49,7 +55,7 @@ interface GetExpResponse {
 interface GetExpByIdResponse {
   httpStatus: number;
   message: string;
-  data: ExpPayload;
+  data: ExpPayload & SubExperience;
 }
 
 interface DeleteExpResponse {
@@ -57,35 +63,23 @@ interface DeleteExpResponse {
   message: string;
 }
 
-export async function saveExp(payload: ExpPayload): Promise<SaveExpResponse> {
-  const res = await API.post<SaveExpResponse>('/api/exp', {
-    ...payload,
-    title: payload.title ?? '',
-    keywords: payload.keywords ?? [],
-    issueDate: payload.issueDate ? new Date(payload.issueDate) : undefined,
-    startDate: payload.startDate ? new Date(payload.startDate) : undefined,
-    endDate: payload.endDate ? new Date(payload.endDate) : undefined,
-  });
+export async function saveExp(
+  payload: ExpPayload & { subExperiences: SubExperience[] }
+): Promise<SaveExpResponse> {
+  const res = await API.post<SaveExpResponse>('/api/exp', payload);
   return res.data;
 }
 
 export async function editExp(
   exp_id: number,
-  payload: ExpPayload
+  payload: ExpPayload & { subExperiences: SubExperience[] }
 ): Promise<SaveExpResponse> {
-  const res = await API.patch<SaveExpResponse>(`/api/exp/${exp_id}`, {
-    ...payload,
-    issueDate: payload.issueDate ? new Date(payload.issueDate) : undefined,
-    startDate: payload.startDate ? new Date(payload.startDate) : undefined,
-    endDate: payload.endDate ? new Date(payload.endDate) : undefined,
-  });
-
+  const res = await API.patch<SaveExpResponse>(`/api/exp/${exp_id}`, payload);
   return res.data;
 }
 
 export async function getExpById(exp_id: number): Promise<GetExpByIdResponse> {
   const res = await API.get<GetExpByIdResponse>(`/api/exp/${exp_id}`);
-
   return res.data;
 }
 

--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -30,6 +30,7 @@ export interface Exp {
   id: number;
   title: string;
   experienceType: ExpType;
+  draftTime?: string;
   status: ExpStatus;
   keywords: string[];
 }

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { editExp, saveExp, type ExpPayload } from '@/apis/exp';
+import { editExp, saveExp, SubExperience, type ExpPayload } from '@/apis/exp';
 import FormTab from './FormTab';
 import Popup from '@/app/components/Popup';
 import GuideModal from './GuideModal';
@@ -16,37 +16,45 @@ import StarForm from './StarForm';
 import SimpleForm from './SimpleForm';
 
 interface ExpFormProps {
-  data?: ExpPayload;
+  data: ExpPayload & { subExperiencesResponseDto: SubExperience[] };
 }
 
-const getInitialForm = (data?: ExpPayload & { selectedTab?: string }) => ({
-  selectedTab:
-    data?.formType === 'STAR_FORM'
-      ? 'star'
-      : data?.formType === 'SIMPLE_FORM'
-        ? 'simple'
-        : 'star',
-  status: data?.status || 'SAVE',
-  formType: data?.formType || 'STAR_FORM',
-  uploadType: data?.uploadType || 'FILE',
-  experienceType: data?.experienceType || ('' as ExpType),
-  qualification: data?.qualification || '',
-  publisher: data?.publisher || '',
-  issueDate: data?.issueDate || '',
-  simpleDescription: data?.simpleDescription || '',
-  title: data?.title || '',
-  startDate: data?.startDate || '',
-  endDate: data?.endDate || '',
-  role: data?.role || '',
-  perform: data?.perform || '',
-  situation: data?.situation || '',
-  task: data?.task || '',
-  action: data?.action || '',
-  result: data?.result || '',
-  files: data?.files || [],
-  keywords: data?.keywords || [],
-  id: data?.id,
-});
+const getInitialForm = (
+  data?: ExpPayload & { subExperiencesResponseDto?: SubExperience[] }
+) => {
+  const sub = data?.subExperiencesResponseDto?.[0];
+
+  return {
+    subExperiences: data?.subExperiencesResponseDto || [],
+    selectedTab:
+      sub?.formType === 'STAR_FORM'
+        ? 'star'
+        : sub?.formType === 'SIMPLE_FORM'
+          ? 'simple'
+          : 'star',
+    status: sub?.status || 'SAVE',
+    formType: sub?.formType || 'STAR_FORM',
+    uploadType: sub?.uploadType || 'FILE',
+    experienceType: data?.experienceType || ('' as ExpType),
+    qualification: data?.qualification || '',
+    publisher: data?.publisher || '',
+    issueDate: data?.issueDate || '',
+    simpleDescription: sub?.simpleDescription || '',
+    title: data?.title || '',
+    startDate: data?.startDate || '',
+    endDate: data?.endDate || '',
+    role: sub?.role || '',
+    perform: sub?.perform || '',
+    situation: sub?.situation || '',
+    task: sub?.task || '',
+    action: sub?.action || '',
+    result: sub?.result || '',
+    files: sub?.files || [],
+    keywords: sub?.keywords || [],
+    id: data?.id,
+    subId: sub?.id,
+  };
+};
 
 export default function ExpForm({ data }: ExpFormProps) {
   const router = useRouter();
@@ -81,7 +89,7 @@ export default function ExpForm({ data }: ExpFormProps) {
 
     if (!data) {
       const allEmpty = keysToCompare.every(key => {
-        const val = form[key];
+        const val = form[key as keyof typeof form];
         if (val === undefined || val === null) return true;
         if (typeof val === 'string' && val.trim() === '') return true;
         if (Array.isArray(val) && val.length === 0) return true;
@@ -91,7 +99,10 @@ export default function ExpForm({ data }: ExpFormProps) {
     }
 
     return keysToCompare.some(key => {
-      return JSON.stringify(form[key]) !== JSON.stringify(data[key]);
+      return (
+        JSON.stringify(form[key as keyof typeof form]) !==
+        JSON.stringify(data[key])
+      );
     });
   };
 
@@ -136,14 +147,24 @@ export default function ExpForm({ data }: ExpFormProps) {
 
     const payload: ExpPayload = {
       ...form,
-      issueDate: form.issueDate ? new Date(form.issueDate) : undefined,
-      startDate: form.startDate ? new Date(form.startDate) : undefined,
-      endDate: form.endDate ? new Date(form.endDate) : undefined,
+      issueDate: form.issueDate
+        ? new Date(form.issueDate).toISOString()
+        : undefined,
+      startDate: form.startDate
+        ? new Date(form.startDate).toISOString()
+        : undefined,
+      endDate: form.endDate ? new Date(form.endDate).toISOString() : undefined,
     };
 
     const { httpStatus, message } = form.id
-      ? await editExp(form.id, payload)
-      : await saveExp(payload);
+      ? await editExp(form.id, {
+          ...payload,
+          subExperiences: form.subExperiences,
+        })
+      : await saveExp({
+          ...payload,
+          subExperiences: form.subExperiences || [],
+        });
 
     if (httpStatus == 200) {
       alert('성공적으로 저장되었습니다!');

--- a/app/(main)/exp/[id]/page.tsx
+++ b/app/(main)/exp/[id]/page.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { ExpPayload, getExpById, deleteExp, editExp } from '@/apis/exp';
+import {
+  ExpPayload,
+  getExpById,
+  deleteExp,
+  editExp,
+  SubExperience,
+} from '@/apis/exp';
 import { EXP_OPTIONS } from '@/constants/expOptions';
 import { useRouter } from 'next/navigation';
 import Popup from '@/app/components/Popup';
@@ -15,6 +21,7 @@ export default function ExpDetailPage() {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [editData, setEditData] = useState<ExpPayload>({} as ExpPayload);
   const [data, setData] = useState<ExpPayload | null>(null);
+  const [subData, setSubData] = useState<SubExperience | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -29,6 +36,9 @@ export default function ExpDetailPage() {
         const res = await getExpById(expId);
         setData(res.data);
         setEditData(res.data);
+
+        const firstSub = res.data.subExperiences?.[0] ?? null;
+        setSubData(firstSub);
       } catch {
         setError('경험 데이터를 불러오는 데 실패했습니다.');
       }
@@ -50,7 +60,9 @@ export default function ExpDetailPage() {
       {data.issueDate && (
         <p>수상일: {new Date(data.issueDate).toLocaleDateString('ko-KR')}</p>
       )}
-      {data.simpleDescription && <p>간단 설명: {data.simpleDescription}</p>}
+      {subData?.simpleDescription && (
+        <p>간단 설명: {subData.simpleDescription}</p>
+      )}
     </>
   );
 
@@ -61,7 +73,9 @@ export default function ExpDetailPage() {
       {data.issueDate && (
         <p>취득일: {new Date(data.issueDate).toLocaleDateString('ko-KR')}</p>
       )}
-      {data.simpleDescription && <p>간단 설명: {data.simpleDescription}</p>}
+      {subData?.simpleDescription && (
+        <p>간단 설명: {subData.simpleDescription}</p>
+      )}
     </>
   );
 
@@ -73,8 +87,8 @@ export default function ExpDetailPage() {
           {new Date(data.endDate).toLocaleDateString('ko-KR')}
         </p>
       )}
-      {data.role && <p>역할: {data.role}</p>}
-      {data.perform && <p>주요 성과: {data.perform}</p>}
+      {subData?.role && <p>역할: {subData.role}</p>}
+      {subData?.perform && <p>주요 성과: {subData.perform}</p>}
     </>
   );
 
@@ -87,22 +101,22 @@ export default function ExpDetailPage() {
           {new Date(data.endDate).toLocaleDateString('ko-KR')}
         </p>
       )}
-      {data.situation && <p>상황: {data.situation}</p>}
-      {data.task && <p>문제: {data.task}</p>}
-      {data.action && <p>행동: {data.action}</p>}
-      {data.result && <p>결과: {data.result}</p>}
+      {subData?.situation && <p>상황: {subData.situation}</p>}
+      {subData?.task && <p>문제: {subData.task}</p>}
+      {subData?.action && <p>행동: {subData.action}</p>}
+      {subData?.result && <p>결과: {subData.result}</p>}
     </>
   );
 
   const renderDetailContent = () => {
-    if (data.formType === 'SIMPLE_FORM') {
+    if (subData?.formType === 'SIMPLE_FORM') {
       if (data.experienceType === 'PRIZE') return renderPrizeSection();
       if (data.experienceType === 'CERTIFICATES')
         return renderCertificateSection();
       return renderSimpleSection();
     }
 
-    if (data.formType === 'STAR_FORM') return renderStarSection();
+    if (subData?.formType === 'STAR_FORM') return renderStarSection();
 
     return null;
   };
@@ -147,7 +161,10 @@ export default function ExpDetailPage() {
           <button
             type="button"
             onClick={async () => {
-              await editExp(Number(params?.id), editData);
+              await editExp(Number(params?.id), {
+                ...editData,
+                subExperiences: editData.subExperiences ?? [],
+              });
             }}
             className="w-20 py-3 bg-primary-50 text-sm text-gray-1100 font-semibold rounded-lg"
           >
@@ -169,7 +186,7 @@ export default function ExpDetailPage() {
             </h3>
             <div className="bg-gray-700 p-3 rounded-[4px] border border-gray-600">
               <div className="flex flex-wrap gap-2">
-                {data.keywords?.map((keyword: string, idx: number) => (
+                {subData?.keywords?.map((keyword: string, idx: number) => (
                   <span
                     key={idx}
                     className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100"

--- a/app/(main)/exp/components/AddExpBtn.tsx
+++ b/app/(main)/exp/components/AddExpBtn.tsx
@@ -29,7 +29,7 @@ export default function AddExpBtn() {
           router.push('/addExp');
         }}
       >
-        <EditPencilIcon className="stroke-gray-1100" />
+        <EditPencilIcon className="stroke-gray-1100 w-[30px] h-[30px]" />
       </div>
     </div>
   );

--- a/app/(main)/exp/components/BtnFilter.tsx
+++ b/app/(main)/exp/components/BtnFilter.tsx
@@ -9,12 +9,17 @@ import { ExpType } from '@/types/exp';
 
 interface BtnFilterProps {
   onSelectType: (type: ExpType | null) => void;
+  onSelectSort: (sort: 'latest' | 'oldest') => void;
 }
 
-export default function BtnFilter({ onSelectType }: BtnFilterProps) {
+export default function BtnFilter({
+  onSelectType,
+  onSelectSort,
+}: BtnFilterProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedType, setSelectedType] = useState<ExpType | null>(null);
   const options = Object.values(EXP_OPTIONS);
+  const [sortOrder, setSortOrder] = useState<'latest' | 'oldest'>('latest');
 
   const handleSelectType = (type: ExpType) => {
     if (type === null) {
@@ -23,6 +28,11 @@ export default function BtnFilter({ onSelectType }: BtnFilterProps) {
       setSelectedType(type);
     }
     onSelectType(type);
+  };
+
+  const handleSelectSort = (sort: 'latest' | 'oldest') => {
+    setSortOrder(sort);
+    onSelectSort(sort);
   };
 
   return (
@@ -58,8 +68,16 @@ export default function BtnFilter({ onSelectType }: BtnFilterProps) {
             </div>
             <div className="text-gray-50 text-xl">정렬 방식</div>
             <div className="flex gap-4">
-              <BtnExpType label="최신순" selected={true} onClick={() => {}} />
-              <BtnExpType label="과거순" selected={false} onClick={() => {}} />
+              <BtnExpType
+                label="최신순"
+                selected={sortOrder === 'latest'}
+                onClick={() => handleSelectSort('latest')}
+              />
+              <BtnExpType
+                label="과거순"
+                selected={sortOrder === 'oldest'}
+                onClick={() => handleSelectSort('oldest')}
+              />
             </div>
           </div>
         </div>

--- a/app/(main)/exp/components/BtnFilter.tsx
+++ b/app/(main)/exp/components/BtnFilter.tsx
@@ -39,7 +39,10 @@ export default function BtnFilter({
     <div className="flex justify-end relative">
       <div className="flex items-center justify-center w-[125px] h-[40px] bg-gray-1000 border border-gray-50-20 rounded-lg text-gray-300 text-sm">
         전체•최신순
-        <ArrowDownIcon onClick={() => setIsOpen(!isOpen)} />
+        <ArrowDownIcon
+          onClick={() => setIsOpen(!isOpen)}
+          className="w-[24px] h-[24px]"
+        />
       </div>
       {isOpen && (
         <div className="flex flex-col absolute justify-center w-[597px] h-[457px] top-[60px] bg-gray-1000 rounded-lg border border-gray-50-20 z-50 p-4">

--- a/app/(main)/exp/components/ExpCard.tsx
+++ b/app/(main)/exp/components/ExpCard.tsx
@@ -32,6 +32,30 @@ export default function ExpCard({
     router.push(`/exp/${id}`);
   };
 
+  const formattedDraftTime = draftTime
+    ? (() => {
+        const date = new Date(draftTime);
+        const today = new Date();
+        const isToday =
+          date.getFullYear() === today.getFullYear() &&
+          date.getMonth() === today.getMonth() &&
+          date.getDate() === today.getDate();
+
+        if (isToday) {
+          return date.toLocaleTimeString('ko-KR', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: true,
+          });
+        } else {
+          const yyyy = date.getFullYear();
+          const mm = String(date.getMonth() + 1).padStart(2, '0');
+          const dd = String(date.getDate()).padStart(2, '0');
+          return `${yyyy}-${mm}-${dd}`;
+        }
+      })()
+    : null;
+
   return (
     <div
       className="relative w-[322px] h-[224px] border 
@@ -49,7 +73,7 @@ export default function ExpCard({
         {isTemp && draftTime && (
           <div className="flex gap-1.5 items-center body-14-m text-gray-300 whitespace-nowrap">
             <ClockIcon />
-            <span>{new Date(draftTime).toLocaleDateString('ko-KR')}</span>
+            <span>{formattedDraftTime}</span>
             <span>임시저장</span>
           </div>
         )}

--- a/app/(main)/exp/components/ExpCard.tsx
+++ b/app/(main)/exp/components/ExpCard.tsx
@@ -48,7 +48,6 @@ export default function ExpCard({
             hour12: true,
           });
         } else {
-          // 연-월-일 포맷
           const yyyy = date.getFullYear();
           const mm = String(date.getMonth() + 1).padStart(2, '0');
           const dd = String(date.getDate()).padStart(2, '0');

--- a/app/(main)/exp/components/ExpCard.tsx
+++ b/app/(main)/exp/components/ExpCard.tsx
@@ -12,11 +12,18 @@ interface ExpCardProps {
   id: number;
   title: string;
   type: ExpType;
+  draftTime?: string;
   status: ExpStatus;
   keywords: string[];
 }
 
-export default function ExpCard({ id, title, type, status }: ExpCardProps) {
+export default function ExpCard({
+  id,
+  title,
+  type,
+  draftTime,
+  status,
+}: ExpCardProps) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const isTemp = status === 'DRAFT';
   const router = useRouter();
@@ -39,10 +46,11 @@ export default function ExpCard({ id, title, type, status }: ExpCardProps) {
         <div className="body-20-r text-gray-50">{title}</div>
       </div>
       <div className="flex flex-row justify-between items-center relative">
-        {isTemp && (
+        {isTemp && draftTime && (
           <div className="flex gap-1.5 items-center body-14-m text-gray-300 whitespace-nowrap">
             <ClockIcon />
-            임시저장
+            <span>{new Date(draftTime).toLocaleDateString('ko-KR')}</span>
+            <span>임시저장</span>
           </div>
         )}
         <button

--- a/app/(main)/exp/components/ExpList.tsx
+++ b/app/(main)/exp/components/ExpList.tsx
@@ -32,7 +32,7 @@ export default function ExpList({ data }: ExpListProps) {
 
   return (
     <main className="flex-1 flex-col items-start py-16 px-[80px]">
-      <div className="fixed top-[65vh] right-[49px] z-50">
+      <div className="fixed top-[75vh] right-[49px] z-50">
         <AddExpBtn />
       </div>
       <h1 className="text-[25px] font-bold mb-6">내 경험</h1>

--- a/app/(main)/exp/components/ExpList.tsx
+++ b/app/(main)/exp/components/ExpList.tsx
@@ -51,6 +51,7 @@ export default function ExpList({ data }: ExpListProps) {
               id={exp.id}
               title={exp.title}
               type={exp.experienceType}
+              draftTime={exp.draftTime}
               status={exp.status}
               keywords={exp.keywords}
             />

--- a/app/(main)/exp/components/ExpList.tsx
+++ b/app/(main)/exp/components/ExpList.tsx
@@ -38,7 +38,12 @@ export default function ExpList({ data }: ExpListProps) {
       <h1 className="text-[25px] font-bold mb-6">내 경험</h1>
       <div className="flex justify-between mb-7">
         <SearchBar onSearch={setSearchTerm} />
-        <BtnFilter onSelectType={setSelectedType} />
+        <BtnFilter
+          onSelectType={setSelectedType}
+          onSelectSort={sort => {
+            fetch(`api/exp?sort=${sort}`);
+          }}
+        />
       </div>
 
       {!data || data.length === 0 ? (

--- a/app/components/Profile.tsx
+++ b/app/components/Profile.tsx
@@ -14,7 +14,10 @@ export default function Profile() {
       <div className="flex items-center justify-center gap-1.5 text-gray-50 font-semibold">
         <Image src="/images/profile.svg" alt="profile" width={36} height={36} />
         <p className="whitespace-nowrap">김잇타</p>
-        <ArrowDownIcon onClick={() => setIsOpen(!isOpen)} />
+        <ArrowDownIcon
+          onClick={() => setIsOpen(!isOpen)}
+          className="w-[24px] h-[24px]"
+        />
         {isOpen && (
           <div className="flex flex-col absolute top-full justify-center">
             <div className="flex bg-gray-800 w-44 px-5 py-2.5 text-gray-50 text-xs">


### PR DESCRIPTION
## 📌 연관된 이슈

- close #116 

## 📝작업 내용

- expPayload에서 subExperience를 배열로 받아오도록 API 수정
- 임시저장 시간 표시 (오늘이면 시간, 아니면 연-월-일)
- 아이콘 크기 수정

=> 경험 저장 / 경험 search(제목/키워드) 가능!
(최신순•과거순은 아직 작동 전입니다)

### 스크린샷 (선택)

임시저장 시간
![image](https://github.com/user-attachments/assets/2eb17741-707c-4a42-b033-ce70d144feff)

## 💬리뷰 요구사항
