### PR TITLE
Feat/#128: 타임라인 컴포넌트 개발

### DIFF
--- a/apis/dashboard.ts
+++ b/apis/dashboard.ts
@@ -53,6 +53,20 @@ export interface CoreSkillMapResponse {
   success: boolean;
 }
 
+export interface TimelineExp {
+  startDate: string;
+  endDate: string;
+  title: string;
+  experienceType: string;
+}
+
+export interface ExpTimelineResponse {
+  httpStatus: number;
+  message: string;
+  data: TimelineExp[];
+  success: boolean;
+}
+
 export async function getJobRatio(): Promise<JobRatioResponse> {
   const res = await API.get<JobRatioResponse>('/api/dashboard/ratio');
 
@@ -86,6 +100,19 @@ export async function getExpHistory(
     `/api/dashboard/history-new?${new URLSearchParams({
       year: year.toString(),
       month: month.toString(),
+    })}`
+  );
+  return res.data;
+}
+
+export async function getExpTimeline(
+  startLine: string,
+  endLine: string
+): Promise<ExpTimelineResponse> {
+  const res = await API.get<ExpTimelineResponse>(
+    `/api/dashboard/timeline?${new URLSearchParams({
+      startLine,
+      endLine,
     })}`
   );
   return res.data;

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -2,27 +2,32 @@ import HelpIcon from '@/public/icons/Circle_Help.svg';
 import Timeline from '@/app/components/commons/Timeline';
 import { getExpTimeline } from '@/apis/dashboard';
 
-function getStartAndEndLines(): { startLine: string; endLine: string } {
+function getStartAndEndLines(): {
+  start: Date;
+  end: Date;
+  startLine: string;
+  endLine: string;
+} {
   const now = new Date();
 
   // endLine: 이번 달의 마지막 날
   const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-  console.log('end', end);
 
   // startLine: 두 달 전의 첫째 날
   const start = new Date(now.getFullYear(), now.getMonth() - 3, 2);
-  console.log('start', start);
 
   const toString = (date: Date) => date.toISOString().split('T')[0]; // yyyy-mm-dd 형식
 
   return {
+    start: start,
+    end: end,
     startLine: toString(start),
     endLine: toString(end),
   };
 }
 
 export default async function ExpTimeLine() {
-  const { startLine, endLine } = getStartAndEndLines();
+  const { start, end, startLine, endLine } = getStartAndEndLines();
   const Exp = await getExpTimeline(startLine, endLine);
 
   return (
@@ -31,7 +36,7 @@ export default async function ExpTimeLine() {
         <span className="body-16-sb mr-2">경험 타임 라인</span>
         <HelpIcon className="stroke-gray-600 w-[24px] h-[24px]" />
       </div>
-      <Timeline experiences={Exp.data} />
+      <Timeline initialMinDate={start} initialMaxDate={end} exps={Exp.data} />
     </>
   );
 }

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -11,32 +11,20 @@ interface Experience {
 const sampleExperiences: Experience[] = [
   {
     startDate: '2025-03-01',
-    endDate: '2025-06-30',
-    title: '인턴십 A',
+    endDate: '2025-06-29',
+    title: '인턴',
     experienceType: 'INTERN',
   },
   {
-    startDate: '2025-03-01',
-    endDate: '2025-03-10',
-    title: '인턴십 B',
-    experienceType: 'INTERN',
-  },
-  {
-    startDate: '2025-03-15',
-    endDate: '2025-06-20',
-    title: '잇타 동아리 활동',
+    startDate: '2025-03-27',
+    endDate: '2025-05-29',
+    title: '프로젝트3',
     experienceType: 'PROJECT',
   },
   {
-    startDate: '2025-03-30',
-    endDate: '2025-06-22',
-    title: '잇타 동아리 활동2',
-    experienceType: 'PROJECT',
-  },
-  {
-    startDate: '2025-06-24',
-    endDate: '2025-06-24',
-    title: '공모전',
+    startDate: '2025-06-11',
+    endDate: '2025-06-12',
+    title: 'dd공모전',
     experienceType: 'CONTEST',
   },
 ];
@@ -48,7 +36,7 @@ export default function ExpTimeLine() {
         <span className="body-16-sb mr-2">경험 타임 라인</span>
         <HelpIcon className="stroke-gray-600 w-[24px] h-[24px]" />
       </div>
-      <Timeline width={380} experiences={sampleExperiences} />
+      <Timeline experiences={sampleExperiences} />
     </>
   );
 }

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -10,16 +10,16 @@ interface Experience {
 
 const sampleExperiences: Experience[] = [
   {
-    startDate: '2025-03-01',
-    endDate: '2025-06-29',
-    title: '인턴',
-    experienceType: 'INTERN',
-  },
-  {
     startDate: '2025-03-27',
     endDate: '2025-05-29',
     title: '프로젝트3',
     experienceType: 'PROJECT',
+  },
+  {
+    startDate: '2025-04-01',
+    endDate: '2025-06-29',
+    title: '인턴',
+    experienceType: 'INTERN',
   },
   {
     startDate: '2025-06-11',

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -1,42 +1,37 @@
 import HelpIcon from '@/public/icons/Circle_Help.svg';
 import Timeline from '@/app/components/commons/Timeline';
+import { getExpTimeline } from '@/apis/dashboard';
 
-interface Experience {
-  startDate: string;
-  endDate: string;
-  title: string;
-  experienceType: string;
+function getStartAndEndLines(): { startLine: string; endLine: string } {
+  const now = new Date();
+
+  // endLine: 이번 달의 마지막 날
+  const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  console.log('end', end);
+
+  // startLine: 두 달 전의 첫째 날
+  const start = new Date(now.getFullYear(), now.getMonth() - 3, 2);
+  console.log('start', start);
+
+  const toString = (date: Date) => date.toISOString().split('T')[0]; // yyyy-mm-dd 형식
+
+  return {
+    startLine: toString(start),
+    endLine: toString(end),
+  };
 }
 
-const sampleExperiences: Experience[] = [
-  {
-    startDate: '2025-03-27',
-    endDate: '2025-05-29',
-    title: '프로젝트3',
-    experienceType: 'PROJECT',
-  },
-  {
-    startDate: '2025-04-01',
-    endDate: '2025-06-29',
-    title: '인턴',
-    experienceType: 'INTERN',
-  },
-  {
-    startDate: '2025-06-11',
-    endDate: '2025-06-12',
-    title: 'dd공모전',
-    experienceType: 'CONTEST',
-  },
-];
+export default async function ExpTimeLine() {
+  const { startLine, endLine } = getStartAndEndLines();
+  const Exp = await getExpTimeline(startLine, endLine);
 
-export default function ExpTimeLine() {
   return (
     <>
       <div className="flex mb-3">
         <span className="body-16-sb mr-2">경험 타임 라인</span>
         <HelpIcon className="stroke-gray-600 w-[24px] h-[24px]" />
       </div>
-      <Timeline experiences={sampleExperiences} />
+      <Timeline experiences={Exp.data} />
     </>
   );
 }

--- a/app/(main)/dashboard/components/JobRatio.tsx
+++ b/app/(main)/dashboard/components/JobRatio.tsx
@@ -14,13 +14,13 @@ export default function JobRatio({
     <>
       <div className="flex flex-row items-center justify-center">
         {/* 차트 */}
-        <PieChart width={170} height={170}>
+        <PieChart width={180} height={190}>
           <Pie
             data={data}
             cx={85}
             cy={85}
-            innerRadius={50}
-            outerRadius={70}
+            innerRadius={60}
+            outerRadius={85}
             fill="#FF6D01"
             dataKey="value"
             stroke="none"
@@ -43,7 +43,7 @@ export default function JobRatio({
           </Pie>
         </PieChart>
         {/* 범례 */}
-        <div className="ml-10 flex flex-col justify-center">
+        <div className="ml-5 flex flex-col justify-center">
           <ul>
             {data.map((item, idx) => (
               <li key={item.name} className="flex items-center mb-3 last:mb-0">

--- a/app/(main)/dashboard/components/JobRatioContainer.tsx
+++ b/app/(main)/dashboard/components/JobRatioContainer.tsx
@@ -13,8 +13,8 @@ export default function JobRatioContainer({
   jobRatio: JobRatioResponse | null;
 }) {
   return (
-    <div className="flex-[38] bg-gray-800 rounded-[23px] py-8 px-10 h-[270px] flex flex-col">
-      <div className="flex mb-3">
+    <div className="flex-[38] bg-gray-800 rounded-[23px] py-4 px-5 h-[270px] flex flex-col">
+      <div className="flex mb-3 mt-4 ml-5">
         <span className="body-16-sb mr-2">직무 비율</span>
         <HelpIcon className="stroke-gray-600 w-[24px] h-[24px]" />
       </div>

--- a/app/(main)/dashboard/components/Scrap.tsx
+++ b/app/(main)/dashboard/components/Scrap.tsx
@@ -24,7 +24,7 @@ function ScrapCard({ title, dday }: { title: string; dday: number }) {
     <div className="flex justify-between items-center border-b border-gray-50-20 py-[10px]">
       <div className="body-12-m text-gray-50 whitespace-pre-line">{title}</div>
       <div
-        className={`body-14-m ${dday <= 7 ? 'text-gray-50' : 'text-gray-500'}`}
+        className={`body-14-m whitespace-nowrap ${dday <= 7 ? 'text-gray-50' : 'text-gray-500'}`}
       >
         D-{dday}
       </div>

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -2,7 +2,7 @@ import ProfileCard from './components/ProfileCard';
 import ExpHistory from './components/ExpHistory';
 import Scrap from './components/Scrap';
 import ExpTimeLine from './components/ExpTimeLine';
-import { getExpHistory } from '@/apis/dashboard';
+import { getExpHistory, getExpTimeline } from '@/apis/dashboard';
 import Footer from '@/app/components/Footer';
 import {
   LazyJobRatioContainer,
@@ -18,6 +18,33 @@ export default async function DashboardPage() {
     new Date().getFullYear(),
     new Date().getMonth() + 1
   );
+
+  function getStartAndEndLines(): {
+    start: Date;
+    end: Date;
+    startLine: string;
+    endLine: string;
+  } {
+    const now = new Date();
+
+    // endLine: 이번 달의 마지막 날
+    const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+
+    // startLine: 두 달 전의 첫째 날
+    const start = new Date(now.getFullYear(), now.getMonth() - 3, 2);
+
+    const toString = (date: Date) => date.toISOString().split('T')[0]; // yyyy-mm-dd 형식
+
+    return {
+      start: start,
+      end: end,
+      startLine: toString(start),
+      endLine: toString(end),
+    };
+  }
+
+  const { start, end, startLine, endLine } = getStartAndEndLines();
+  const expTimeline = await getExpTimeline(startLine, endLine);
 
   return (
     <div className="min-h-screen py-6 px-14">
@@ -39,7 +66,7 @@ export default async function DashboardPage() {
         </div>
         <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
           <div className="flex-[2.5] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
-            <ExpTimeLine />
+            <ExpTimeLine start={start} end={end} expTimeline={expTimeline} />
           </div>
           <div className="flex-[1] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
             <ExpHistory expHistory={expHistory} />

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -38,13 +38,13 @@ export default async function DashboardPage() {
           </div>
         </div>
         <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
-          <div className="flex-[2] bg-gray-800 rounded-[23px] py-8 px-10">
+          <div className="flex-[2.5] bg-gray-800 rounded-[23px] py-8 px-8">
             <ExpTimeLine />
           </div>
-          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-10">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-8">
             <ExpHistory expHistory={expHistory} />
           </div>
-          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-10">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-8">
             <Scrap />
           </div>
         </div>

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -38,13 +38,13 @@ export default async function DashboardPage() {
           </div>
         </div>
         <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
-          <div className="flex-[2.5] bg-gray-800 rounded-[23px] py-8 px-8">
+          <div className="flex-[2.5] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
             <ExpTimeLine />
           </div>
-          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-8">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
             <ExpHistory expHistory={expHistory} />
           </div>
-          <div className="flex-[1] bg-gray-800 rounded-[23px] py-8 px-8">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
             <Scrap />
           </div>
         </div>

--- a/app/(main)/scrap/page.tsx
+++ b/app/(main)/scrap/page.tsx
@@ -1,0 +1,3 @@
+export default function ScarpPage() {
+  return <div>스크랩 기능은 준비중입니다.</div>;
+}

--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -7,11 +7,10 @@ import { usePathname } from 'next/navigation';
 import VectorIcon from '@/public/icons/Vector.svg';
 import BookIcon from '@/public/icons/Book.svg';
 import CopyIcon from '@/public/icons/Copy.svg';
-import FileDocumentIcon from '@/public/icons/File_Document.svg';
 import BookmarkIcon from '@/public/icons/Bookmark.svg';
 import UserCircleIcon from '@/public/icons/User_Circle.svg';
 
-const SideBar = () => {
+export default function SideBar() {
   const pathname = usePathname();
 
   const iconStyle = (currentPath: string) => {
@@ -75,6 +74,4 @@ const SideBar = () => {
       </nav>
     </aside>
   );
-};
-
-export default SideBar;
+}

--- a/app/components/SideBar.tsx
+++ b/app/components/SideBar.tsx
@@ -60,26 +60,16 @@ const SideBar = () => {
             isActive={pathname.startsWith('/growth-guide')}
           />
           <SideBarMenu
-            href="/ai-self-introduction"
-            icon={
-              <FileDocumentIcon
-                className={iconStyle('/ai-self-introduction')}
-              />
-            }
-            text="AI 자기소개서"
-            isActive={pathname.startsWith('/ai-self-introduction')}
-          />
-          <SideBarMenu
-            href="/bookmark"
+            href="/scrap"
             icon={<BookmarkIcon className={iconStyle('/bookmark')} />}
-            text="북마크"
+            text="스크랩"
             isActive={pathname.startsWith('/bookmark')}
           />
           <SideBarMenu
-            href="/my-page"
-            icon={<UserCircleIcon className={iconStyle('/my-page')} />}
+            href="/profile"
+            icon={<UserCircleIcon className={iconStyle('/profile')} />}
             text="마이페이지"
-            isActive={pathname.startsWith('/my-page')}
+            isActive={pathname.startsWith('/profile')}
           />
         </ul>
       </nav>

--- a/app/components/commons/BtnNext.tsx
+++ b/app/components/commons/BtnNext.tsx
@@ -8,7 +8,7 @@ export default function BtnNext({ moveNext }: BtnNextProps) {
   return (
     <button
       onClick={() => moveNext(1)}
-      className="flex items-center justify-center bg-gray-700 rounded-lg w-[28px] h-[28px] cursor-pointer mx-1.5 hover:bg-gray-600 transition"
+      className="flex items-center justify-center bg-gray-700 rounded-lg w-[28px] h-[28px] cursor-pointer hover:bg-gray-600 transition"
       aria-label="다음 달"
     >
       <BackIcon className="stroke-gray-100 rotate-180" width={15} height={15} />

--- a/app/components/commons/BtnPrev.tsx
+++ b/app/components/commons/BtnPrev.tsx
@@ -9,7 +9,7 @@ export default function BtnPrev({ movePrev }: BtnPrevProps) {
     <button
       onClick={() => movePrev(-1)}
       type="button"
-      className="flex items-center justify-center bg-gray-700 rounded-lg w-[28px] h-[28px] cursor-pointer mx-1.5 hover:bg-gray-600 transition"
+      className="flex items-center justify-center bg-gray-700 rounded-lg w-[28px] h-[28px] cursor-pointer hover:bg-gray-600 transition"
       aria-label="이전 달"
     >
       <BackIcon className="stroke-gray-100" width={15} height={15} />

--- a/app/components/commons/CalendarDays.tsx
+++ b/app/components/commons/CalendarDays.tsx
@@ -36,7 +36,7 @@ export default function CalendarDays({
           return (
             <div
               key={i}
-              className="text-center pt-2 h-[40px] text-gray-300 body-11-m relative select-none"
+              className="text-center pt-2 h-[30px] text-gray-300 body-11-m relative select-none"
             >
               {day}
               {count && <DateMark count={count} />}

--- a/app/components/commons/CalendarDays.tsx
+++ b/app/components/commons/CalendarDays.tsx
@@ -18,7 +18,7 @@ export default function CalendarDays({
 }: CalendarDaysProps) {
   return (
     <>
-      <div className="grid grid-cols-7 my-2 gap-0.5">
+      <div className="grid grid-cols-7 gap-0.5">
         {WEEK_DAYS.map(day => (
           <div
             key={day}

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -54,15 +54,32 @@ export default function Timeline({
     async function fetchTimelineExp() {
       try {
         // TODO: 날짜를 yyyy-mm-dd 형식으로 변환하여 API 호출
-        const response = await getExpTimeline(String(newMin), String(newMax));
+        const response = await getExpTimeline(
+          newMin.toISOString().split('T')[0],
+          newMax.toISOString().split('T')[0]
+        );
         const timeline = response.data;
+        console.log('경험 타임라인:', timeline);
 
         if (!Array.isArray(timeline) || timeline.length === 0) {
-          setExperiences([]);
           return;
         }
 
-        setExperiences(timeline);
+        setExperiences(prev => {
+          // 중복을 제거한 새로운 경험만 필터링
+          const newItems = timeline.filter(
+            newItem =>
+              !prev.some(
+                prevItem =>
+                  prevItem.startDate === newItem.startDate &&
+                  prevItem.endDate === newItem.endDate &&
+                  prevItem.title === newItem.title &&
+                  prevItem.experienceType === newItem.experienceType
+              )
+          );
+
+          return [...prev, ...newItems];
+        });
       } catch (error) {
         console.error('경험 타임라인 불러오기 실패:', error);
         setExperiences([]);
@@ -165,14 +182,17 @@ export default function Timeline({
             const h = 30;
             const y = exp.rowIndex * (h + gap);
 
-            return TimelineLabel({
-              idx,
-              x1,
-              x2,
-              y,
-              h,
-              exp,
-            });
+            return (
+              <TimelineLabel
+                key={idx}
+                idx={idx}
+                x1={x1}
+                x2={x2}
+                y={y}
+                h={h}
+                exp={exp}
+              />
+            );
           })}
         </svg>
       </div>

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useEffect, useState } from 'react';
+import { useMemo, useRef, useEffect } from 'react';
 import useResponsiveWidth from '@/hooks/useResponsiveWidth';
 import { EXP_COLORS } from '@/constants/expColors';
 import BtnPrev from './BtnPrev';
@@ -37,7 +37,7 @@ export default function Timeline({
   experiences = [],
   width = '100%',
   height = 200,
-  padding = 40,
+  padding = 10,
 }: TimelineProps) {
   const parseISO = (dateStr: string): Date => new Date(dateStr);
   const differenceInDays = (date1: Date, date2: Date): number =>
@@ -90,7 +90,7 @@ export default function Timeline({
     };
   }, [placedBar]);
 
-  const gap = 3;
+  const gap = 1;
   const rowHeight = (height - padding * 2 - gap * (rowsCount - 1)) / rowsCount;
 
   const monthLabels = useMemo(() => {
@@ -103,7 +103,7 @@ export default function Timeline({
     return labels;
   }, [minDate, maxDate]);
 
-  const [textWidths, setTextWidths] = useState<number[]>([]);
+  //const [textWidths, setTextWidths] = useState<number[]>([]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -111,12 +111,13 @@ export default function Timeline({
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.font = '14px sans-serif';
-    setTextWidths(placedBar.map(exp => ctx.measureText(exp.title).width));
+    //setTextWidths(placedBar.map(exp => ctx.measureText(exp.title).width));
   }, [placedBar]);
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center gap-2 mb-3">
+      <div className="mb-3">2025</div>
+      <div className="flex items-center mb-3 gap-2">
         <BtnPrev movePrev={() => {}} />
         <div className="flex-1 flex gap-2" ref={containerRef}>
           {monthLabels.map(label => (
@@ -148,49 +149,45 @@ export default function Timeline({
               (differenceInDays(exp._end, minDate) / totalDays) *
                 (numericWidth - padding * 2);
             const y = padding + exp.rowIndex * (rowHeight + gap);
-            const thinH = 6,
-              thickH = 24;
-            const textW = textWidths[idx] || 0;
-            const highlightW = Math.max(Math.min(80, x2 - x1), textW + 24);
+            const h = 30;
+            //const textW = textWidths[idx] || 0;
+
+            //기간이 짧을 때 원 반환
             if (x2 - x1 < 40)
               return (
                 <circle
                   key={idx}
                   cx={x1 + 1}
-                  cy={y + thickH / 2}
+                  cy={y + h / 2}
                   r={12}
                   fill={EXP_COLORS[exp.experienceType] || '#666'}
                 />
               );
             return (
               <g key={idx}>
-                <circle
-                  cx={x1 + (x2 - x1) - 9}
-                  cy={y + thickH / 2 - 2}
-                  r={9}
-                  fill={EXP_COLORS[exp.experienceType] || '#666'}
-                />
                 <rect
                   x={x1}
-                  y={y + thickH / 2 - 5}
-                  width={Math.max(x2 - x1, 1)}
-                  height={thinH}
+                  y={y}
+                  width={3}
+                  height={h}
                   rx={2}
                   fill={EXP_COLORS[exp.experienceType] || '#666'}
                 />
                 <rect
                   x={x1}
                   y={y}
-                  width={highlightW}
-                  height={thickH}
+                  width={Math.max(x2 - x1, 1)}
+                  height={h}
                   rx={4}
                   fill={EXP_COLORS[exp.experienceType] || '#666'}
+                  fillOpacity={0.2}
                 />
                 <text
                   x={x1 + 15}
-                  y={y + thickH / 2 + 6}
+                  y={y + h / 2 + 6}
                   fontSize={14}
-                  fill="#000"
+                  fontWeight={400}
+                  fill="#fff"
                 >
                   {exp.title}
                 </text>

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useEffect } from 'react';
+import { useMemo, useRef } from 'react';
 import useResponsiveWidth from '@/hooks/useResponsiveWidth';
 import { EXP_COLORS } from '@/constants/expColors';
 import BtnPrev from './BtnPrev';
@@ -35,13 +35,17 @@ export default function Timeline({
   minDate = new Date('2025-03-01'),
   maxDate = new Date('2025-06-30'),
 }: TimelineProps) {
+  //날짜 문자열을 Date 객체로 변환하는 함수
   const parseISO = (dateStr: string): Date => new Date(dateStr);
+
+  //두 날짜 사이의 일수 차이를 계산하는 함수
   const differenceInDays = (date1: Date, date2: Date): number =>
     Math.floor((date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24));
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const numericWidth = useResponsiveWidth(containerRef, width, 1000);
+  const numericWidth = useResponsiveWidth(containerRef, width, 500);
 
+  //string 타입의 경험 데이터를 Date 객체로 변환하고 정렬
   const parsed = useMemo<ParsedExperience[]>(
     () =>
       experiences
@@ -54,6 +58,7 @@ export default function Timeline({
     [experiences]
   );
 
+  //경험 데이터의 기간이 겹칠 경우 다른 row로 분리
   const placedBar = useMemo<PlacedExperience[]>(() => {
     const rows: Row[] = [];
     return parsed.map(exp => {
@@ -66,21 +71,20 @@ export default function Timeline({
     });
   }, [parsed]);
 
-  interface DateRange {
-    totalDays: number;
-    rowsCount: number;
-  }
-  const { totalDays } = useMemo<DateRange>(() => {
+  //최소 날짜와 최대 날짜 사이의 총 일수 계산
+  const { totalDays } = useMemo<{ totalDays: number }>(() => {
     const days = differenceInDays(maxDate, minDate) || 1;
 
     return {
       totalDays: days,
-      rowsCount: Math.max(1, ...placedBar.map(e => e.rowIndex + 1)),
     };
-  }, [maxDate, minDate, placedBar]);
+  }, [maxDate, minDate]);
 
+  //row 간 간격
   const gap = 10;
 
+  //최소 날짜부터 최대 날짜까지의 월 레이블을 생성
+  //예: ["1월", "2월", "3월", ...]
   const monthLabels = useMemo(() => {
     const labels: string[] = [];
     const dt = new Date(minDate.getFullYear(), minDate.getMonth(), 1);
@@ -91,18 +95,11 @@ export default function Timeline({
     return labels;
   }, [minDate, maxDate]);
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    ctx.font = '14px sans-serif';
-  }, [placedBar]);
-
   return (
     <div className="flex flex-col">
       <div className="mb-3">2025</div>
       <div className="flex items-center mb-3 gap-2">
+        {/* 월 */}
         <BtnPrev movePrev={() => {}} />
         <div className="flex-1 flex gap-2" ref={containerRef}>
           {monthLabels.map(label => (
@@ -132,7 +129,6 @@ export default function Timeline({
               (differenceInDays(exp._end, minDate) / totalDays) * numericWidth;
             const h = 30;
             const y = exp.rowIndex * (h + gap);
-            //const textW = textWidths[idx] || 0;
 
             //기간이 짧을 때 텍스트 미표시
             if (x2 - x1 < 40)

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import useResponsiveWidth from '@/hooks/useResponsiveWidth';
-import { EXP_COLORS } from '@/constants/expColors';
 import BtnPrev from './BtnPrev';
 import BtnNext from './BtnNext';
-import { TimelineExp } from '@/apis/dashboard';
+import { getExpTimeline, TimelineExp } from '@/apis/dashboard';
+import TimelineLabel from './TimelineLabel';
 
 interface ParsedExperience extends TimelineExp {
   _start: Date;
@@ -21,31 +21,71 @@ interface Row {
 }
 
 interface TimelineProps {
-  experiences: TimelineExp[];
+  exps: TimelineExp[];
   width?: number | string;
   height?: number;
-  minDate?: Date;
-  maxDate?: Date;
+  initialMinDate?: Date;
+  initialMaxDate?: Date;
 }
 
 export default function Timeline({
-  experiences = [],
+  exps = [],
   width = '100%',
   height = 170,
-  minDate = new Date('2025-03-01'),
-  maxDate = new Date('2025-06-30'),
+  initialMinDate = new Date('2025-03-01'),
+  initialMaxDate = new Date('2025-06-30'),
 }: TimelineProps) {
-  //날짜 문자열을 Date 객체로 변환하는 함수
-  const parseISO = (dateStr: string): Date => new Date(dateStr);
-
-  //두 날짜 사이의 일수 차이를 계산하는 함수
-  const differenceInDays = (date1: Date, date2: Date): number =>
-    Math.floor((date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24));
-
   const containerRef = useRef<HTMLDivElement>(null);
   const numericWidth = useResponsiveWidth(containerRef, width, 500);
 
-  //string 타입의 경험 데이터를 Date 객체로 변환하고 정렬
+  const [minDate, setMinDate] = useState(initialMinDate);
+  const [maxDate, setMaxDate] = useState(initialMaxDate);
+  const [experiences, setExperiences] = useState<TimelineExp[]>(exps);
+
+  // 1달 이전으로 이동
+  const handlePrev = () => {
+    const newMin = new Date(minDate);
+    newMin.setMonth(minDate.getMonth() - 1);
+    const newMax = new Date(maxDate);
+    newMax.setMonth(maxDate.getMonth() - 1);
+    setMinDate(newMin);
+    setMaxDate(newMax);
+
+    async function fetchTimelineExp() {
+      try {
+        // TODO: 날짜를 yyyy-mm-dd 형식으로 변환하여 API 호출
+        const response = await getExpTimeline(String(newMin), String(newMax));
+        const timeline = response.data;
+
+        if (!Array.isArray(timeline) || timeline.length === 0) {
+          setExperiences([]);
+          return;
+        }
+
+        setExperiences(timeline);
+      } catch (error) {
+        console.error('경험 타임라인 불러오기 실패:', error);
+        setExperiences([]);
+      }
+    }
+
+    fetchTimelineExp();
+  };
+
+  // 1달 이후로 이동
+  const handleNext = () => {
+    const newMin = new Date(minDate);
+    newMin.setMonth(minDate.getMonth() + 1);
+    const newMax = new Date(maxDate);
+    newMax.setMonth(maxDate.getMonth() + 1);
+    setMinDate(newMin);
+    setMaxDate(newMax);
+  };
+
+  const parseISO = (dateStr: string): Date => new Date(dateStr);
+  const differenceInDays = (date1: Date, date2: Date): number =>
+    Math.floor((date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24));
+
   const parsed = useMemo<ParsedExperience[]>(
     () =>
       experiences
@@ -58,7 +98,6 @@ export default function Timeline({
     [experiences]
   );
 
-  //경험 데이터의 기간이 겹칠 경우 다른 row로 분리
   const placedBar = useMemo<PlacedExperience[]>(() => {
     const rows: Row[] = [];
     return parsed.map(exp => {
@@ -66,29 +105,24 @@ export default function Timeline({
       if (rowIndex === -1) {
         rows.push({ end: exp._end });
         rowIndex = rows.length - 1;
-      } else rows[rowIndex].end = exp._end;
+      } else {
+        rows[rowIndex].end = exp._end;
+      }
       return { ...exp, rowIndex };
     });
   }, [parsed]);
 
-  //최소 날짜와 최대 날짜 사이의 총 일수 계산
-  const { totalDays } = useMemo<{ totalDays: number }>(() => {
+  const { totalDays } = useMemo(() => {
     const days = differenceInDays(maxDate, minDate) || 1;
-
-    return {
-      totalDays: days,
-    };
+    return { totalDays: days };
   }, [maxDate, minDate]);
 
-  //row 간 간격
   const gap = 10;
 
-  //최소 날짜부터 최대 날짜까지의 월 레이블을 생성
-  //예: ["1월", "2월", "3월", ...]
   const monthLabels = useMemo(() => {
     const labels: string[] = [];
     const dt = new Date(minDate.getFullYear(), minDate.getMonth(), 1);
-    while (dt <= maxDate) {
+    while (dt < maxDate) {
       labels.push(`${dt.getMonth() + 1}월`);
       dt.setMonth(dt.getMonth() + 1);
     }
@@ -97,11 +131,13 @@ export default function Timeline({
 
   return (
     <div className="flex flex-col">
-      <div className="mb-3">2025</div>
+      <div className="mb-3">{minDate.getFullYear()}</div>
       <div className="flex items-center mb-3 gap-2">
-        {/* 월 */}
-        <BtnPrev movePrev={() => {}} />
-        <div className="flex-1 flex gap-2" ref={containerRef}>
+        <BtnPrev movePrev={handlePrev} />
+        <div
+          className="flex-1 flex gap-2 overflow-x-auto no-scrollbar"
+          ref={containerRef}
+        >
           {monthLabels.map(label => (
             <div
               key={label}
@@ -111,10 +147,9 @@ export default function Timeline({
             </div>
           ))}
         </div>
-        <BtnNext moveNext={() => {}} />
+        <BtnNext moveNext={handleNext} />
       </div>
 
-      {/* Timeline SVG */}
       <div className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden">
         <svg
           width={numericWidth}
@@ -130,59 +165,14 @@ export default function Timeline({
             const h = 30;
             const y = exp.rowIndex * (h + gap);
 
-            //기간이 짧을 때 텍스트 미표시
-            if (x2 - x1 < 40)
-              return (
-                <g key={idx}>
-                  <rect
-                    x={x1}
-                    y={y}
-                    width={3}
-                    height={h}
-                    rx={2}
-                    fill={EXP_COLORS[exp.experienceType] || '#666'}
-                  />
-                  <rect
-                    x={x1}
-                    y={y}
-                    width={Math.max(x2 - x1, 1)}
-                    height={h}
-                    rx={4}
-                    fill={EXP_COLORS[exp.experienceType] || '#666'}
-                    fillOpacity={0.2}
-                  />
-                </g>
-              );
-            return (
-              <g key={idx}>
-                <rect
-                  x={x1}
-                  y={y}
-                  width={3}
-                  height={h}
-                  rx={2}
-                  fill={EXP_COLORS[exp.experienceType] || '#666'}
-                />
-                <rect
-                  x={x1}
-                  y={y}
-                  width={Math.max(x2 - x1, 1)}
-                  height={h}
-                  rx={4}
-                  fill={EXP_COLORS[exp.experienceType] || '#666'}
-                  fillOpacity={0.2}
-                />
-                <text
-                  x={x1 + 15}
-                  y={y + h / 2 + 6}
-                  fontSize={14}
-                  fontWeight={400}
-                  fill="#fff"
-                >
-                  {exp.title}
-                </text>
-              </g>
-            );
+            return TimelineLabel({
+              idx,
+              x1,
+              x2,
+              y,
+              h,
+              exp,
+            });
           })}
         </svg>
       </div>

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -5,15 +5,9 @@ import useResponsiveWidth from '@/hooks/useResponsiveWidth';
 import { EXP_COLORS } from '@/constants/expColors';
 import BtnPrev from './BtnPrev';
 import BtnNext from './BtnNext';
+import { TimelineExp } from '@/apis/dashboard';
 
-interface Experience {
-  startDate: string;
-  endDate: string;
-  title: string;
-  experienceType: string;
-}
-
-interface ParsedExperience extends Experience {
+interface ParsedExperience extends TimelineExp {
   _start: Date;
   _end: Date;
 }
@@ -27,7 +21,7 @@ interface Row {
 }
 
 interface TimelineProps {
-  experiences: Experience[];
+  experiences: TimelineExp[];
   width?: number | string;
   height?: number;
   minDate?: Date;

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -66,7 +66,7 @@ export default function Timeline({
     return { totalDays: days };
   }, [maxDate, minDate]);
 
-  const gap = 10;
+  const gap = 20;
 
   return (
     <div className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden">

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef } from 'react';
 import useResponsiveWidth from '@/hooks/useResponsiveWidth';
-import BtnPrev from './BtnPrev';
-import BtnNext from './BtnNext';
-import { getExpTimeline, TimelineExp } from '@/apis/dashboard';
+import { TimelineExp } from '@/apis/dashboard';
 import TimelineLabel from './TimelineLabel';
 
 interface ParsedExperience extends TimelineExp {
@@ -24,110 +22,44 @@ interface TimelineProps {
   exps: TimelineExp[];
   width?: number | string;
   height?: number;
-  initialMinDate?: Date;
-  initialMaxDate?: Date;
+  minDate?: Date;
+  maxDate?: Date;
 }
 
 export default function Timeline({
-  exps = [],
+  exps,
   width = '100%',
   height = 170,
-  initialMinDate = new Date('2025-03-01'),
-  initialMaxDate = new Date('2025-06-30'),
+  minDate = new Date('2025-03-01'),
+  maxDate = new Date('2025-06-30'),
 }: TimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const numericWidth = useResponsiveWidth(containerRef, width, 500);
 
-  const [minDate, setMinDate] = useState(initialMinDate);
-  const [maxDate, setMaxDate] = useState(initialMaxDate);
-  const [experiences, setExperiences] = useState<TimelineExp[]>(exps);
-
-  // 1달 이전으로 이동
-  const handlePrev = () => {
-    const newMin = new Date(minDate);
-    newMin.setMonth(minDate.getMonth() - 1);
-    const newMax = new Date(maxDate);
-    newMax.setMonth(maxDate.getMonth() - 1);
-    setMinDate(newMin);
-    setMaxDate(newMax);
-
-    async function fetchTimelineExp() {
-      try {
-        // TODO: 날짜를 yyyy-mm-dd 형식으로 변환하여 API 호출
-        const response = await getExpTimeline(
-          newMin.toISOString().split('T')[0],
-          newMax.toISOString().split('T')[0]
-        );
-        const timeline = response.data;
-        console.log('경험 타임라인:', timeline);
-
-        if (!Array.isArray(timeline) || timeline.length === 0) {
-          return;
-        }
-
-        setExperiences(prev => {
-          // 중복을 제거한 새로운 경험만 필터링
-          const newItems = timeline.filter(
-            newItem =>
-              !prev.some(
-                prevItem =>
-                  prevItem.startDate === newItem.startDate &&
-                  prevItem.endDate === newItem.endDate &&
-                  prevItem.title === newItem.title &&
-                  prevItem.experienceType === newItem.experienceType
-              )
-          );
-
-          return [...prev, ...newItems];
-        });
-      } catch (error) {
-        console.error('경험 타임라인 불러오기 실패:', error);
-        setExperiences([]);
-      }
-    }
-
-    fetchTimelineExp();
-  };
-
-  // 1달 이후로 이동
-  const handleNext = () => {
-    const newMin = new Date(minDate);
-    newMin.setMonth(minDate.getMonth() + 1);
-    const newMax = new Date(maxDate);
-    newMax.setMonth(maxDate.getMonth() + 1);
-    setMinDate(newMin);
-    setMaxDate(newMax);
-  };
-
-  const parseISO = (dateStr: string): Date => new Date(dateStr);
   const differenceInDays = (date1: Date, date2: Date): number =>
     Math.floor((date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24));
 
-  const parsed = useMemo<ParsedExperience[]>(
-    () =>
-      experiences
-        .map(exp => ({
-          ...exp,
-          _start: parseISO(exp.startDate),
-          _end: parseISO(exp.endDate),
-        }))
-        .sort((a, b) => a._start.getTime() - b._start.getTime()),
-    [experiences]
-  );
-
   const placedBar = useMemo<PlacedExperience[]>(() => {
     const rows: Row[] = [];
-    return parsed.map(exp => {
-      let rowIndex = rows.findIndex(row => exp._start > row.end);
-      if (rowIndex === -1) {
-        rows.push({ end: exp._end });
-        rowIndex = rows.length - 1;
-      } else {
-        rows[rowIndex].end = exp._end;
-      }
-      return { ...exp, rowIndex };
-    });
-  }, [parsed]);
+
+    return exps
+      .map(exp => ({
+        ...exp,
+        _start: new Date(exp.startDate),
+        _end: new Date(exp.endDate),
+      }))
+      .sort((a, b) => a._start.getTime() - b._start.getTime())
+      .map(exp => {
+        let rowIndex = rows.findIndex(row => exp._start > row.end);
+        if (rowIndex === -1) {
+          rows.push({ end: exp._end });
+          rowIndex = rows.length - 1;
+        } else {
+          rows[rowIndex].end = exp._end;
+        }
+        return { ...exp, rowIndex };
+      });
+  }, [exps]);
 
   const { totalDays } = useMemo(() => {
     const days = differenceInDays(maxDate, minDate) || 1;
@@ -136,66 +68,34 @@ export default function Timeline({
 
   const gap = 10;
 
-  const monthLabels = useMemo(() => {
-    const labels: string[] = [];
-    const dt = new Date(minDate.getFullYear(), minDate.getMonth(), 1);
-    while (dt < maxDate) {
-      labels.push(`${dt.getMonth() + 1}월`);
-      dt.setMonth(dt.getMonth() + 1);
-    }
-    return labels;
-  }, [minDate, maxDate]);
-
   return (
-    <div className="flex flex-col">
-      <div className="mb-3">{minDate.getFullYear()}</div>
-      <div className="flex items-center mb-3 gap-2">
-        <BtnPrev movePrev={handlePrev} />
-        <div
-          className="flex-1 flex gap-2 overflow-x-auto no-scrollbar"
-          ref={containerRef}
-        >
-          {monthLabels.map(label => (
-            <div
-              key={label}
-              className="flex-1 min-w-0 py-2 flex items-center justify-center bg-gray-700 rounded-lg body-12-m"
-            >
-              {label}
-            </div>
-          ))}
-        </div>
-        <BtnNext moveNext={handleNext} />
-      </div>
+    <div className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden">
+      <svg
+        width={numericWidth}
+        height={height}
+        style={{ background: 'transparent', width: `${numericWidth}px` }}
+      >
+        {placedBar.map((exp, idx) => {
+          const x1 =
+            (differenceInDays(exp._start, minDate) / totalDays) * numericWidth;
+          const x2 =
+            (differenceInDays(exp._end, minDate) / totalDays) * numericWidth;
+          const h = 30;
+          const y = exp.rowIndex * (h + gap);
 
-      <div className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden">
-        <svg
-          width={numericWidth}
-          height={height}
-          style={{ background: 'transparent', width: `${numericWidth}px` }}
-        >
-          {placedBar.map((exp, idx) => {
-            const x1 =
-              (differenceInDays(exp._start, minDate) / totalDays) *
-              numericWidth;
-            const x2 =
-              (differenceInDays(exp._end, minDate) / totalDays) * numericWidth;
-            const h = 30;
-            const y = exp.rowIndex * (h + gap);
-
-            return (
-              <TimelineLabel
-                key={idx}
-                idx={idx}
-                x1={x1}
-                x2={x2}
-                y={y}
-                h={h}
-                exp={exp}
-              />
-            );
-          })}
-        </svg>
-      </div>
+          return (
+            <TimelineLabel
+              key={idx}
+              idx={idx}
+              x1={x1}
+              x2={x2}
+              y={y}
+              h={h}
+              exp={exp}
+            />
+          );
+        })}
+      </svg>
     </div>
   );
 }

--- a/app/components/commons/TimelineLabel.tsx
+++ b/app/components/commons/TimelineLabel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { EXP_COLORS } from '@/constants/expColors';
 
 type TimelineLabelProps = {
@@ -9,6 +10,8 @@ type TimelineLabelProps = {
   exp: {
     experienceType: string;
     title: string;
+    startDate: string;
+    endDate: string;
   };
 };
 
@@ -20,56 +23,66 @@ export default function TimelineLabel({
   h,
   exp,
 }: TimelineLabelProps) {
-  if (x2 - x1 < 40) {
-    return (
-      <g key={idx}>
-        <rect
-          x={x1}
-          y={y}
-          width={3}
-          height={h}
-          rx={2}
-          fill={EXP_COLORS[exp.experienceType] || '#666'}
-        />
-        <rect
-          x={x1}
-          y={y}
-          width={Math.max(x2 - x1, 1)}
-          height={h}
-          rx={4}
-          fill={EXP_COLORS[exp.experienceType] || '#666'}
-          fillOpacity={0.2}
-        />
-      </g>
-    );
-  }
+  const [isHovered, setIsHovered] = useState(false);
+
+  const barHeight = isHovered ? h * 1.5 : h;
+  const textX = x1 < 0 && x2 > 0 ? 15 : x1 + 15;
+
+  const fillColor = EXP_COLORS[exp.experienceType] || '#666';
+
   return (
-    <g key={idx}>
+    <g
+      key={idx}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <rect
         x={x1}
         y={y}
         width={3}
-        height={h}
+        height={barHeight}
         rx={2}
-        fill={EXP_COLORS[exp.experienceType] || '#666'}
+        fill={fillColor}
+        style={{
+          transition: 'all 0.3s ease',
+        }}
       />
       <rect
         x={x1}
         y={y}
         width={Math.max(x2 - x1, 1)}
-        height={h}
+        height={barHeight}
         rx={4}
-        fill={EXP_COLORS[exp.experienceType] || '#666'}
+        fill={fillColor}
         fillOpacity={0.2}
+        style={{
+          transition: 'all 0.3s ease',
+        }}
       />
       <text
-        x={x1 + 15}
-        y={y + h / 2 + 6}
+        x={textX}
+        y={y + h / 2 + 5}
         fontSize={14}
         fontWeight={400}
         fill="#fff"
+        style={{
+          transition: 'all 0.3s ease',
+        }}
       >
         {exp.title}
+      </text>
+      <text
+        x={textX}
+        y={y + h / 2 + 23}
+        fontSize={12}
+        fontWeight={400}
+        fill="#fff"
+        style={{
+          opacity: isHovered ? 0.5 : 0,
+          transition: 'all 0.3s ease',
+        }}
+      >
+        {exp.startDate}-{exp.endDate}
       </text>
     </g>
   );

--- a/app/components/commons/TimelineLabel.tsx
+++ b/app/components/commons/TimelineLabel.tsx
@@ -60,26 +60,28 @@ export default function TimelineLabel({
         }}
       />
       <text
-        x={textX}
+        x={0}
         y={y + h / 2 + 5}
         fontSize={14}
         fontWeight={400}
         fill="#fff"
+        transform={`translate(${textX}, 0)`}
         style={{
-          transition: 'all 0.3s ease',
+          transition: 'transform 0.3s ease',
         }}
       >
         {exp.title}
       </text>
       <text
-        x={textX}
+        x={0}
         y={y + h / 2 + 23}
         fontSize={12}
         fontWeight={400}
         fill="#fff"
+        transform={`translate(${textX}, 0)`}
         style={{
           opacity: isHovered ? 0.5 : 0,
-          transition: 'all 0.3s ease',
+          transition: 'transform 0.3s ease',
         }}
       >
         {exp.startDate}-{exp.endDate}

--- a/app/components/commons/TimelineLabel.tsx
+++ b/app/components/commons/TimelineLabel.tsx
@@ -1,0 +1,76 @@
+import { EXP_COLORS } from '@/constants/expColors';
+
+type TimelineLabelProps = {
+  idx: number;
+  x1: number;
+  x2: number;
+  y: number;
+  h: number;
+  exp: {
+    experienceType: string;
+    title: string;
+  };
+};
+
+export default function TimelineLabel({
+  idx,
+  x1,
+  x2,
+  y,
+  h,
+  exp,
+}: TimelineLabelProps) {
+  if (x2 - x1 < 40) {
+    return (
+      <g key={idx}>
+        <rect
+          x={x1}
+          y={y}
+          width={3}
+          height={h}
+          rx={2}
+          fill={EXP_COLORS[exp.experienceType] || '#666'}
+        />
+        <rect
+          x={x1}
+          y={y}
+          width={Math.max(x2 - x1, 1)}
+          height={h}
+          rx={4}
+          fill={EXP_COLORS[exp.experienceType] || '#666'}
+          fillOpacity={0.2}
+        />
+      </g>
+    );
+  }
+  return (
+    <g key={idx}>
+      <rect
+        x={x1}
+        y={y}
+        width={3}
+        height={h}
+        rx={2}
+        fill={EXP_COLORS[exp.experienceType] || '#666'}
+      />
+      <rect
+        x={x1}
+        y={y}
+        width={Math.max(x2 - x1, 1)}
+        height={h}
+        rx={4}
+        fill={EXP_COLORS[exp.experienceType] || '#666'}
+        fillOpacity={0.2}
+      />
+      <text
+        x={x1 + 15}
+        y={y + h / 2 + 6}
+        fontSize={14}
+        fontWeight={400}
+        fill="#fff"
+      >
+        {exp.title}
+      </text>
+    </g>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,7 @@
   --color-gray-500: rgb(102, 102, 102);
   --color-gray-500-20: rgb(102, 102, 102, 0.2);
   --color-gray-600: rgb(74, 74, 74);
+  --color-gray-600-20: rgb(74, 74, 74, 0.2);
   --color-gray-700: rgb(36, 36, 36);
   --color-gray-800: rgb(22, 22, 22);
   --color-gray-900: rgb(17, 17, 17);


### PR DESCRIPTION
## 📌 연관된 이슈

- close #128 

## 📝작업 내용

- 직무 비율 차트 크기 키우기
- sidebar ai 자기소개서 메뉴 삭제
- 타임라인 컴포넌트 개발
- 마우스 올리면 기간 보이게 구현했습니다!

### 스크린샷 (선택)

https://github.com/user-attachments/assets/f6f4f8be-a88f-41b5-a40d-ede75a1f43b6

## 💬리뷰 요구사항

타임라인 기간이 너무 짧은 경우 (영상 속에서는 dd공모전 예시. 공모전, 자격증 등)은 글자가 타임라인 막대바 보다 크기가 길어지는데, 이런 경우는 어떻게 처리하면 좋을 지 고민이라 figma에 코멘트 남겨뒀습니다! 논의 후 수정할게요
