### PR TITLE
fix/#156: profile 정보 null일 경우 에러 처리

### DIFF
--- a/apis/profile.ts
+++ b/apis/profile.ts
@@ -20,8 +20,13 @@ export interface ProfileInfo {
 
 export async function getProfileInfo(): Promise<ProfileInfoResponse> {
   const res = await API.get('/api/members');
+  console.log('프로필 정보 불러오기', res.data);
 
-  if (res.status !== 200) {
+  if (
+    res.status !== 200 ||
+    !res.data.desiredDetailRecruit ||
+    !res.data.educationName
+  ) {
     console.log('프로필 정보 불러오기 실패', res.data);
     redirect('/profile');
   }

--- a/app/(main)/dashboard/components/ProfileCard.tsx
+++ b/app/(main)/dashboard/components/ProfileCard.tsx
@@ -18,16 +18,22 @@ export default function ProfileCard({
       <div
         className={
           `px-4 py-1 bg-primary rounded-full text-gray-1000 ` +
-          (profileInfo.desiredDetailRecruit.length > 7
+          (profileInfo.desiredDetailRecruit?.length > 7
             ? 'body-10-m'
             : 'body-12-m')
         }
       >
-        {profileInfo.desiredDetailRecruit}
+        {profileInfo.desiredDetailRecruit
+          ? profileInfo.desiredDetailRecruit
+          : '희망 직무를 입력해주세요'}
       </div>
       <h2 className="my-2 body-16-sb">{profileInfo.name}</h2>
       <div className="body-9-r text-gray-300 stroke-gray-300 flex flex-col">
-        <p className="break-keep">{profileInfo.educationName}</p>
+        <p className="break-keep">
+          {profileInfo.educationName
+            ? profileInfo.educationName
+            : '학력 정보를 입력해주세요'}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## 📌 연관된 이슈

- close #156

## 📝작업 내용

카카오 로그인 이후 dashboard로 이동하고, dashboard에서 profile 정보를 get할 때 에러가 발생하면 /profile로 이동하는 로직이었는데,
profile정보의 일부가 null이어도 에러가 발생하지 않게 변경되어 프론트도 이에 맞게 null이 없을 경우 에러처리하고 일부 정보가 null일 경우 /profile로 redirect하도록 수정했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항
