### PR TITLE
Feat/#150: 대시보드 디자인 수정사항 반영

### DIFF
--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -94,12 +94,16 @@ export default function ExpTimeLine({
   };
   return (
     <>
-      <DashboardHeader
-        title={DASHBOARD_INFO.EXP_TIMELINE.title}
-        info={DASHBOARD_INFO.EXP_TIMELINE.info}
-      />
+      <div className="flex flex-row justify-between">
+        <DashboardHeader
+          title={DASHBOARD_INFO.EXP_TIMELINE.title}
+          info={DASHBOARD_INFO.EXP_TIMELINE.info}
+        />
+        <div className="mb-3 body-14-m text-gray-400">
+          {maxDate.getFullYear()}
+        </div>
+      </div>
       <div className="flex flex-col">
-        <div className="mb-3">{start.getFullYear()}</div>
         <div className="flex items-center mb-3 gap-2">
           <BtnPrev movePrev={handlePrev} />
           <div className="flex-1 flex gap-2 overflow-x-auto no-scrollbar">

--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -93,7 +93,7 @@ export default function ExpTimeLine({
     setMaxDate(newMax);
   };
   return (
-    <>
+    <div className="w-full">
       <div className="flex flex-row justify-between">
         <DashboardHeader
           title={DASHBOARD_INFO.EXP_TIMELINE.title}
@@ -120,6 +120,6 @@ export default function ExpTimeLine({
         </div>
       </div>
       <Timeline minDate={minDate} maxDate={maxDate} exps={experiences} />
-    </>
+    </div>
   );
 }

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -23,31 +23,8 @@ export default function SkillMap({
   const [showStrengthFeedback, setShowStrengthFeedback] = useState(false);
   const [showWeaknessFeedback, setShowWeaknessFeedback] = useState(false);
 
-  if (showStrengthFeedback) {
-    return (
-      <SkillMapReport
-        feedbackType={SKILLMAP_REPORT.STRENGTH.type}
-        feedbackDescription={SKILLMAP_REPORT.STRENGTH.description}
-        feedbackName={strengthFeedback.strengthName}
-        suggestion={strengthFeedback.careerSuggestion}
-        onClose={() => setShowStrengthFeedback(false)}
-      />
-    );
-  }
-  if (showWeaknessFeedback) {
-    return (
-      <SkillMapReport
-        feedbackType={SKILLMAP_REPORT.WEEKNESS.type}
-        feedbackDescription={SKILLMAP_REPORT.WEEKNESS.description}
-        feedbackName={weaknessFeedback.weaknessName}
-        suggestion={weaknessFeedback.improvementSuggestion}
-        onClose={() => setShowWeaknessFeedback(false)}
-      />
-    );
-  }
-
   return (
-    <div className="relative py-8 px-10">
+    <div className="relative pt-8 px-10">
       <DashboardHeader
         title={DASHBOARD_INFO.SKILL_MAP.title}
         info={DASHBOARD_INFO.SKILL_MAP.info}
@@ -101,7 +78,7 @@ export default function SkillMap({
           </button>
         </div>
       </div>
-      {/* {showStrengthFeedback && (
+      {showStrengthFeedback && (
         <SkillMapReport
           feedbackType={SKILLMAP_REPORT.STRENGTH.type}
           feedbackDescription={SKILLMAP_REPORT.STRENGTH.description}
@@ -118,7 +95,7 @@ export default function SkillMap({
           suggestion={weaknessFeedback.improvementSuggestion}
           onClose={() => setShowWeaknessFeedback(false)}
         />
-      )} */}
+      )}
     </div>
   );
 }

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -23,6 +23,29 @@ export default function SkillMap({
   const [showStrengthFeedback, setShowStrengthFeedback] = useState(false);
   const [showWeaknessFeedback, setShowWeaknessFeedback] = useState(false);
 
+  if (showStrengthFeedback) {
+    return (
+      <SkillMapReport
+        feedbackType={SKILLMAP_REPORT.STRENGTH.type}
+        feedbackDescription={SKILLMAP_REPORT.STRENGTH.description}
+        feedbackName={strengthFeedback.strengthName}
+        suggestion={strengthFeedback.careerSuggestion}
+        onClose={() => setShowStrengthFeedback(false)}
+      />
+    );
+  }
+  if (showWeaknessFeedback) {
+    return (
+      <SkillMapReport
+        feedbackType={SKILLMAP_REPORT.WEEKNESS.type}
+        feedbackDescription={SKILLMAP_REPORT.WEEKNESS.description}
+        feedbackName={weaknessFeedback.weaknessName}
+        suggestion={weaknessFeedback.improvementSuggestion}
+        onClose={() => setShowWeaknessFeedback(false)}
+      />
+    );
+  }
+
   return (
     <div className="relative py-8 px-10">
       <DashboardHeader
@@ -78,7 +101,7 @@ export default function SkillMap({
           </button>
         </div>
       </div>
-      {showStrengthFeedback && (
+      {/* {showStrengthFeedback && (
         <SkillMapReport
           feedbackType={SKILLMAP_REPORT.STRENGTH.type}
           feedbackDescription={SKILLMAP_REPORT.STRENGTH.description}
@@ -95,7 +118,7 @@ export default function SkillMap({
           suggestion={weaknessFeedback.improvementSuggestion}
           onClose={() => setShowWeaknessFeedback(false)}
         />
-      )}
+      )} */}
     </div>
   );
 }

--- a/app/(main)/dashboard/components/SkillMapReport.tsx
+++ b/app/(main)/dashboard/components/SkillMapReport.tsx
@@ -16,25 +16,29 @@ export default function SkillMapReport({
   onClose,
 }: SkillMapReportProps) {
   return (
-    <div className="absolute top-0 left-0 w-full h-[214px] py-8 px-10 rounded-[23px] bg-gray-800 flex flex-col z-10">
-      <div className="flex justify-between items-center">
-        <div className="body-16-sb">
-          <span className="text-gray-50">{feedbackType}: </span>
-          <span className="text-primary">{feedbackName}</span>
+    <div className="relative py-8 px-10">
+      <div className="absolute top-0 left-0 w-full h-[214px] py-8 px-10 rounded-[23px] bg-gray-800 flex flex-col z-10">
+        <div className="flex justify-between items-center">
+          <div className="body-16-sb">
+            <span className="text-gray-50">{feedbackType}: </span>
+            <span className="text-primary">{feedbackName}</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-200 cursor-pointer"
+          >
+            ✕
+          </button>
         </div>
-        <button
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-200 cursor-pointer"
-        >
-          ✕
-        </button>
-      </div>
-      <div className="text-gray-400 body-11-m mt-2">{feedbackDescription}</div>
-      <div className="mt-10">
-        <div className="text-primary body-9-r mb-2">{feedbackName}</div>
-        <p className="text-gray-200 body-11-m whitespace-pre-wrap">
-          {suggestion}
-        </p>
+        <div className="text-gray-400 body-11-m mt-2">
+          {feedbackDescription}
+        </div>
+        <div className="mt-10">
+          <div className="text-primary body-9-r mb-2">{feedbackName}</div>
+          <p className="text-gray-200 body-11-m whitespace-pre-wrap">
+            {suggestion}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/app/(main)/dashboard/components/SkillMapReport.tsx
+++ b/app/(main)/dashboard/components/SkillMapReport.tsx
@@ -16,29 +16,25 @@ export default function SkillMapReport({
   onClose,
 }: SkillMapReportProps) {
   return (
-    <div className="relative py-8 px-10">
-      <div className="absolute top-0 left-0 w-full h-[214px] py-8 px-10 rounded-[23px] bg-gray-800 flex flex-col z-10">
-        <div className="flex justify-between items-center">
-          <div className="body-16-sb">
-            <span className="text-gray-50">{feedbackType}: </span>
-            <span className="text-primary">{feedbackName}</span>
-          </div>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-200 cursor-pointer"
-          >
-            ✕
-          </button>
+    <div className="absolute top-0 left-0 w-full h-full py-8 px-10 rounded-[23px] bg-gray-800 flex flex-col z-10">
+      <div className="flex justify-between items-center">
+        <div className="body-16-sb">
+          <span className="text-gray-50">{feedbackType}: </span>
+          <span className="text-primary">{feedbackName}</span>
         </div>
-        <div className="text-gray-400 body-11-m mt-2">
-          {feedbackDescription}
-        </div>
-        <div className="mt-10">
-          <div className="text-primary body-9-r mb-2">{feedbackName}</div>
-          <p className="text-gray-200 body-11-m whitespace-pre-wrap">
-            {suggestion}
-          </p>
-        </div>
+        <button
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-200 cursor-pointer"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="text-gray-400 body-11-m mt-2">{feedbackDescription}</div>
+      <div className="mt-10">
+        <div className="text-primary body-9-r mb-2">{feedbackName}</div>
+        <p className="text-gray-200 body-11-m whitespace-pre-wrap">
+          {suggestion}
+        </p>
       </div>
     </div>
   );

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -29,10 +29,10 @@ export default async function DashboardPage() {
   } {
     const now = new Date();
 
-    // endLine: 이번 달의 마지막 날
+    // end: 이번 달의 마지막 날
     const end = new Date(now.getFullYear(), now.getMonth() + 1, 1);
 
-    // startLine: 두 달 전의 첫째 날
+    // start: 두 달 전의 첫째 날
     const start = new Date(now.getFullYear(), now.getMonth() - 3, 2);
 
     const toString = (date: Date) => date.toISOString().split('T')[0]; // yyyy-mm-dd 형식
@@ -40,8 +40,8 @@ export default async function DashboardPage() {
     return {
       start: start,
       end: end,
-      startLine: toString(start),
-      endLine: toString(end),
+      startLine: toString(new Date(now.getFullYear(), 0, 1)),
+      endLine: toString(new Date(now.getFullYear(), 11, 31)),
     };
   }
 

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -26,6 +26,10 @@ interface TimelineProps {
   maxDate?: Date;
 }
 
+function formatDate(dateStr: string): string {
+  return dateStr.replace(/-/g, '.');
+}
+
 export default function Timeline({
   exps,
   width = '100%',
@@ -91,7 +95,11 @@ export default function Timeline({
               x2={x2}
               y={y}
               h={h}
-              exp={exp}
+              exp={{
+                ...exp,
+                startDate: formatDate(exp.startDate),
+                endDate: formatDate(exp.endDate),
+              }}
             />
           );
         })}

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -33,12 +33,13 @@ function formatDate(dateStr: string): string {
 export default function Timeline({
   exps,
   width = '100%',
-  height = 170,
+  height = 205,
   minDate = new Date('2025-03-01'),
   maxDate = new Date('2025-06-30'),
 }: TimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const numericWidth = useResponsiveWidth(containerRef, width, 500);
+  console.log('Timeline width:', numericWidth);
 
   const differenceInDays = (date1: Date, date2: Date): number =>
     Math.floor((date1.getTime() - date2.getTime()) / (1000 * 60 * 60 * 24));
@@ -73,7 +74,10 @@ export default function Timeline({
   const gap = 20;
 
   return (
-    <div className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden">
+    <div
+      ref={containerRef}
+      className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden"
+    >
       <svg
         width={numericWidth}
         height={height}

--- a/app/components/commons/TimelineLabel.tsx
+++ b/app/components/commons/TimelineLabel.tsx
@@ -53,25 +53,27 @@ export default function TimelineLabel({
     >
       {/* 작은 세로 막대 */}
       <rect
-        x={x1}
+        x={0}
         y={y}
         width={3}
         height={barHeight}
         rx={2}
         fill={fillColor}
-        style={{ transition: 'all 0.3s ease' }}
+        transform={`translate(${x1}, 0)`}
+        style={{ transition: 'transform 0.3s ease' }}
       />
 
       {/* 길이 막대 */}
       <rect
-        x={x1}
+        x={0}
         y={y}
         width={barWidth}
         height={barHeight}
         rx={4}
         fill={fillColor}
         fillOpacity={0.2}
-        style={{ transition: 'all 0.3s ease' }}
+        transform={`translate(${x1}, 0)`}
+        style={{ transition: 'transform 0.3s ease' }}
       />
 
       {/* 텍스트 */}

--- a/app/components/commons/TimelineLabel.tsx
+++ b/app/components/commons/TimelineLabel.tsx
@@ -56,11 +56,13 @@ export default function TimelineLabel({
         x={0}
         y={y}
         width={3}
-        height={barHeight}
         rx={2}
         fill={fillColor}
         transform={`translate(${x1}, 0)`}
-        style={{ transition: 'transform 0.3s ease' }}
+        style={{
+          height: barHeight,
+          transition: 'height 0.3s ease, transform 0.3s ease',
+        }}
       />
 
       {/* 길이 막대 */}
@@ -68,12 +70,14 @@ export default function TimelineLabel({
         x={0}
         y={y}
         width={barWidth}
-        height={barHeight}
         rx={4}
         fill={fillColor}
         fillOpacity={0.2}
         transform={`translate(${x1}, 0)`}
-        style={{ transition: 'transform 0.3s ease' }}
+        style={{
+          height: barHeight,
+          transition: 'height 0.3s ease, transform 0.3s ease',
+        }}
       />
 
       {/* 텍스트 */}
@@ -112,7 +116,7 @@ export default function TimelineLabel({
         transform={`translate(${textX}, 0)`}
         style={{
           opacity: isHovered ? 0.5 : 0,
-          transition: 'transform 0.3s ease',
+          transition: 'opacity 0.3s ease, transform 0.3s ease',
         }}
       >
         {exp.startDate}-{exp.endDate}

--- a/app/components/commons/TimelineLabel.tsx
+++ b/app/components/commons/TimelineLabel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { EXP_COLORS } from '@/constants/expColors';
 
 type TimelineLabelProps = {
@@ -24,11 +24,26 @@ export default function TimelineLabel({
   exp,
 }: TimelineLabelProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const textRef = useRef<SVGTextElement | null>(null);
 
   const barHeight = isHovered ? h * 1.5 : h;
+  const textY = y + h / 2 + 5;
   const textX = x1 < 0 && x2 > 0 ? 15 : x1 + 15;
-
+  const barWidth = Math.max(x2 - x1, 1);
   const fillColor = EXP_COLORS[exp.experienceType] || '#666';
+
+  const [textBBox, setTextBBox] = useState<{ width: number; height: number }>({
+    width: 0,
+    height: 0,
+  });
+
+  // 텍스트의 실제 크기 측정
+  useEffect(() => {
+    if (textRef.current) {
+      const bbox = textRef.current.getBBox();
+      setTextBBox({ width: bbox.width, height: bbox.height });
+    }
+  }, [exp.title]);
 
   return (
     <g
@@ -36,6 +51,7 @@ export default function TimelineLabel({
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
+      {/* 작은 세로 막대 */}
       <rect
         x={x1}
         y={y}
@@ -43,35 +59,48 @@ export default function TimelineLabel({
         height={barHeight}
         rx={2}
         fill={fillColor}
-        style={{
-          transition: 'all 0.3s ease',
-        }}
+        style={{ transition: 'all 0.3s ease' }}
       />
+
+      {/* 길이 막대 */}
       <rect
         x={x1}
         y={y}
-        width={Math.max(x2 - x1, 1)}
+        width={barWidth}
         height={barHeight}
         rx={4}
         fill={fillColor}
         fillOpacity={0.2}
-        style={{
-          transition: 'all 0.3s ease',
-        }}
+        style={{ transition: 'all 0.3s ease' }}
       />
+
+      {/* 텍스트 */}
       <text
+        ref={textRef}
         x={0}
-        y={y + h / 2 + 5}
+        y={textY}
         fontSize={14}
         fontWeight={400}
         fill="#fff"
         transform={`translate(${textX}, 0)`}
-        style={{
-          transition: 'transform 0.3s ease',
-        }}
+        style={{ transition: 'transform 0.3s ease' }}
       >
         {exp.title}
       </text>
+
+      {/* 바 이후 영역을 덮는 반투명 회색 박스 */}
+      <rect
+        x={0}
+        y={textY - textBBox.height + 3}
+        width={15 + textBBox.width}
+        height={textBBox.height + 2}
+        fill="#212121"
+        transform={`translate(${x1 + barWidth}, 0)`}
+        style={{ transition: 'transform 0.3s ease' }}
+        fillOpacity={0.3}
+      />
+
+      {/* 날짜 */}
       <text
         x={0}
         y={y + h / 2 + 23}

--- a/hooks/useResponsiveWidth.ts
+++ b/hooks/useResponsiveWidth.ts
@@ -10,7 +10,7 @@ export default function useResponsiveWidth(
   );
 
   useEffect(() => {
-    if (typeof width === 'string' && ref.current) {
+    if (ref.current) {
       const handleResize = () => {
         if (ref.current) {
           setMeasuredWidth(ref.current.clientWidth);


### PR DESCRIPTION
## 📌 연관된 이슈

- close #150

## 📝작업 내용
- 스킬맵 리포트 클릭했을 때 뒤에있는 컴포넌트 안보이게 수정
- 타임라인 컴포넌트 길이 반응형 적용
- 타임라인 title이 barWidth 벗어날 때 글자 반투명하게 변경
- 애니메이션 좀 더 자연스럽게 수정
- 타임라인 기간 yyyy-mm-dd에서 yyyy.mm.dd로 변경 

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f03c72dc-6112-4324-a586-de30546a2a8d)

https://github.com/user-attachments/assets/43edad39-5533-46b1-a2bb-26b87030d276



## 💬리뷰 요구사항
