### PR TITLE
Fix/#164/file input

### DIFF
--- a/apis/exp.ts
+++ b/apis/exp.ts
@@ -30,6 +30,7 @@ export interface SubExperience {
   perform?: string;
   simpleDescription?: string;
   files?: string[];
+  links?: string[];
   keywords?: string[];
 }
 
@@ -79,6 +80,7 @@ interface SaveFileResponse {
 export async function saveExp(
   payload: ExpPayload & { subExperiences: SubExperience[] }
 ): Promise<SaveExpResponse> {
+  console.log('saveExp payload: ', payload);
   const res = await API.post<SaveExpResponse>('/api/exp', payload);
   return res.data;
 }
@@ -93,6 +95,7 @@ export async function editExp(
 
 export async function getExpById(exp_id: number): Promise<GetExpByIdResponse> {
   const res = await API.get<GetExpByIdResponse>(`/api/exp/${exp_id}`);
+  console.log(res.data.data.subExperiencesResponseDto);
   return res.data;
 }
 

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -114,7 +114,7 @@ export default function ExpForm({ data }: ExpFormProps) {
       task: '',
       action: '',
       result: '',
-      files: [],
+      //files: [],
       keywords: [],
       subId: undefined,
     };
@@ -180,7 +180,7 @@ export default function ExpForm({ data }: ExpFormProps) {
       'task',
       'action',
       'result',
-      'files',
+      //'files',
       'keywords',
     ] as (keyof ExpPayload)[];
 
@@ -243,6 +243,7 @@ export default function ExpForm({ data }: ExpFormProps) {
     setForms(prev => {
       const updated = [...prev];
       updated[activeFormIndex] = { ...updated[activeFormIndex], [key]: value };
+      console.log('변경된 폼:', updated[activeFormIndex]);
       return updated;
     });
   };

--- a/app/(main)/addExp/components/SimpleForm.tsx
+++ b/app/(main)/addExp/components/SimpleForm.tsx
@@ -7,6 +7,7 @@ interface SimpleFormProps {
     subTitle: string;
     role: string;
     perform: string;
+    files: string[];
     keywords: string[];
   };
   onChange: (key: string, value: string | string[]) => void;
@@ -55,7 +56,10 @@ export default function SimpleForm({ data, onChange }: SimpleFormProps) {
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
           자료 첨부(선택)
         </div>
-        <FileInput />
+        <FileInput
+          onFileChange={newFiles => handleChange('files', newFiles)}
+          //onLinkChange={newLinks => handleChange('links', newLinks)}
+        />
       </div>
 
       <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">

--- a/app/(main)/addExp/components/StarForm.tsx
+++ b/app/(main)/addExp/components/StarForm.tsx
@@ -79,7 +79,10 @@ export default function StarForm({ data, onChange }: StarFormProps) {
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
           자료 첨부(선택)
         </div>
-        <FileInput />
+        <FileInput
+          onFileChange={newFiles => handleChange('files', newFiles)}
+          //onLinkChange={newLinks => handleChange('links', newLinks)}
+        />
       </div>
 
       <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">

--- a/app/(main)/exp/components/ExpDetailContent.tsx
+++ b/app/(main)/exp/components/ExpDetailContent.tsx
@@ -177,7 +177,7 @@ export default function ExpDetailContent({
           <h3 className="text-[21px] font-semibold text-white mb-4">
             파일 추가
           </h3>
-          <FileInput />
+          <FileInput onFileChange={newFiles => onChange('files', newFiles)} />
         </div>
       )}
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #164

## 📝작업 내용

파일 업로드 되도록 구현했는데 상세페이지에서 사용자가 업로드한 file name이 아니라 download를 위해 db에 저장된 fileUrl으로 와서 
{name: string, url: string} 구조로 바꾸거나 프론트에서 / 기준으로 3등분 한 다음 _ 기준으로 fileName만 잘라서 UI만 구현한 다음 클릭 하면 원래 온 fileUrl로 download되게 구현해야할 것 같아요

그리고 files랑 links가 구분되지 않고 files만 받게 되어있어서 일단 링크도 같이 files에 넣어서 보냈습니다

files, keywords는 subExpPayload에만 들어가야하는데 그냥 ExpPayload에도 같이 들어가서 백엔드에 보내지고 있어서..! 구조를 수정해야할 것 같은데 어떻게 수정해야할 지 감이 안오네요.. ㅠ,ㅠ


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/19f4fb57-f3f8-4f26-8996-ce3868645b0d)


## 💬리뷰 요구사항
