### PR TITLE
Feat/#165: dashboard 수정사항 반영 (타임라인 바 줄바꿈, 레이더맵 크기 조절)

### DIFF
--- a/app/(main)/dashboard/components/ProfileCard.tsx
+++ b/app/(main)/dashboard/components/ProfileCard.tsx
@@ -15,25 +15,29 @@ export default function ProfileCard({
         height={110}
         className="rounded-full my-3 w-[110px] h-[110px]"
       />
-      <div
-        className={
-          `px-4 py-1 bg-primary rounded-full text-gray-1000 ` +
-          (profileInfo.desiredDetailRecruit?.length > 7
-            ? 'body-10-m'
-            : 'body-12-m')
-        }
-      >
-        {profileInfo.desiredDetailRecruit
-          ? profileInfo.desiredDetailRecruit
-          : '희망 직무를 입력해주세요'}
-      </div>
-      <h2 className="my-2 body-16-sb">{profileInfo.name}</h2>
-      <div className="body-9-r text-gray-300 stroke-gray-300 flex flex-col">
-        <p className="break-keep">
-          {profileInfo.educationName
-            ? profileInfo.educationName
-            : '학력 정보를 입력해주세요'}
-        </p>
+      <div className="flex flex-col items-center text-center">
+        <div
+          className={
+            `px-4 py-1 bg-primary rounded-full text-gray-1000 ` +
+            (profileInfo.desiredDetailRecruit?.length > 7
+              ? 'body-10-m'
+              : 'body-12-m')
+          }
+        >
+          {profileInfo.desiredDetailRecruit
+            ? profileInfo.desiredDetailRecruit
+            : '희망 직무를 입력해주세요'}
+        </div>
+
+        <h2 className="my-2 body-16-sb">{profileInfo.name}</h2>
+
+        <div className="body-9-r text-gray-300 stroke-gray-300 flex flex-col items-center text-center">
+          <p className="break-keep">
+            {profileInfo.educationName
+              ? profileInfo.educationName
+              : '학력 정보를 입력해주세요'}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/app/(main)/dashboard/components/SkillMap.tsx
+++ b/app/(main)/dashboard/components/SkillMap.tsx
@@ -38,20 +38,20 @@ export default function SkillMap({
   const [showWeaknessFeedback, setShowWeaknessFeedback] = useState(false);
 
   return (
-    <div className="relative pt-8 px-10">
+    <div className="relative pt-6 px-8">
       <DashboardHeader
         title={DASHBOARD_INFO.SKILL_MAP.title}
         info={DASHBOARD_INFO.SKILL_MAP.info}
       />
-      <div className="mt-10 flex w-full h-full">
+      <div className="mt-5 flex w-full h-full">
         {/* 차트 영역 */}
         <div>
           <RadarChart
-            width={300}
-            height={150}
+            width={330}
+            height={160}
             cx="50%"
-            cy="50%"
-            outerRadius="80%"
+            cy="60%"
+            outerRadius="90%"
             data={coreSkillMaps}
           >
             <PolarGrid stroke="#444" />
@@ -71,20 +71,27 @@ export default function SkillMap({
         </div>
 
         {/* 설명 영역 */}
-        <div className="pl-4 flex flex-col gap-4 text-left">
-          <button onClick={() => setShowStrengthFeedback(true)}>
+        <div className="pl-4 flex flex-col gap-4 text-left self-end mx-auto">
+          <button
+            onClick={() => setShowStrengthFeedback(true)}
+            className="text-left flex flex-col items-start"
+          >
             <div className="text-gray-300 body-10-m mb-2">강점 역량</div>
             <div className="flex items-center">
-              <div className="inline-block w-3.5 h-3 border-2 border-gray-200 rounded-md mr-2" />
+              <div className="inline-block w-3 h-3 border-2 border-gray-200 rounded-md mr-2" />
               <span className="text-primary body-12-m">
                 {strengthFeedback.strengthName}
               </span>
             </div>
           </button>
-          <button onClick={() => setShowWeaknessFeedback(true)}>
+
+          <button
+            onClick={() => setShowWeaknessFeedback(true)}
+            className="text-left flex flex-col items-start"
+          >
             <div className="text-gray-300 body-10-m mb-2">보완 필요 역량</div>
             <div className="flex items-center">
-              <div className="inline-block w-3.5 h-3 border-2 border-gray-200 rounded-md mr-2" />
+              <div className="inline-block w-3 h-3 border-2 border-gray-200 rounded-md mr-2" />
               <span className="text-primary body-12-m">
                 {weaknessFeedback.weaknessName}
               </span>

--- a/app/(main)/dashboard/components/SkillMapContainer.tsx
+++ b/app/(main)/dashboard/components/SkillMapContainer.tsx
@@ -23,7 +23,7 @@ export default function SkillMapContainer({
 
   return (
     <div className="w-full h-full">
-      <div className="py-8 px-10 flex flex-col h-full">
+      <div className="py-5 px-10 flex flex-col h-full">
         <DashboardHeader
           title={DASHBOARD_INFO.SKILL_MAP.title}
           info={DASHBOARD_INFO.SKILL_MAP.info}

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -57,7 +57,7 @@ export default async function DashboardPage() {
           </div>
           <div className="flex-[7]">
             <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
-              <div className="flex-[38] bg-gray-800 rounded-[23px] py-8 px-10 h-[270px] flex flex-col">
+              <div className="flex-[38] bg-gray-800 rounded-[23px] py-6 px-8 h-[270px] flex flex-col">
                 <DashboardHeader
                   title={DASHBOARD_INFO.JOB_RATIO.title}
                   info={DASHBOARD_INFO.JOB_RATIO.info}
@@ -75,13 +75,13 @@ export default async function DashboardPage() {
           </div>
         </div>
         <div className="flex flex-grow flex-wrap lg:flex-nowrap gap-4 h-auto">
-          <div className="flex-[2.5] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
+          <div className="flex-[2.5] bg-gray-800 rounded-[23px] pt-6 pb-4 px-8">
             <ExpTimeLine start={start} end={end} expTimeline={expTimeline} />
           </div>
-          <div className="flex-[1] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] pt-6 pb-4 px-8">
             <ExpHistory expHistory={expHistory} />
           </div>
-          <div className="flex-[1] bg-gray-800 rounded-[23px] pt-8 pb-4 px-8">
+          <div className="flex-[1] bg-gray-800 rounded-[23px] pt-6 pb-4 px-8">
             <Scrap />
           </div>
         </div>


### PR DESCRIPTION
## 📌 연관된 이슈

- close #165

## 📝작업 내용

- 타임라인 타이틀 글자 길이 기준으로 줄바꿈
- 대시보드 헤더 살짝 위로 올리기
  - 대시보드 py-8->py-6으로 변경 (32px->28px)
- 레이더맵 크기 키우기, 강점 정렬
  - width={300}, height={150} => width={330}, height={160}
- 프로필 정보의 학교, 학과 정보 중앙정렬

### 스크린샷 (선택)
타임라인 바에서 title 길이 기준으로 글자 안겹치게 줄바꿈
![image](https://github.com/user-attachments/assets/c734ab07-b418-4a63-8d5d-30cc92341039)

대시보드 헤더 위치 올리고 레이더 크기 확대/스킬맵 역량 좌측 정렬/프로필 정보 중앙정렬
![image](https://github.com/user-attachments/assets/680bb3f1-a5b2-424e-988c-12a8c0ed5059)


## 💬리뷰 요구사항
