### PR TITLE
Feat/#179/경험메인•경험입력 기능 개선

### DIFF
--- a/app/(main)/addExp/components/AddExpModal.tsx
+++ b/app/(main)/addExp/components/AddExpModal.tsx
@@ -15,6 +15,26 @@ export default function AddExpModal({
   onClose,
 }: AddExpModalProps) {
   const router = useRouter();
+
+  const validateForm = () => {
+    if (!form.experienceType) return false;
+
+    if (
+      form.experienceType === 'CERTIFICATES' ||
+      form.experienceType === 'PRIZE'
+    ) {
+      if (!form.qualification || !form.publisher || !form.issueDate) {
+        return false;
+      }
+    } else {
+      if (!form.title || !form.startDate || !form.endDate) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="w-[1025px] bg-gray-700 rounded-[19.5px] outline outline-gray-50-20 p-10">
@@ -127,6 +147,10 @@ export default function AddExpModal({
             type="button"
             className="flex justify-center w-72 px-52 py-4 bg-primary-50 font-body-23-b font-bold rounded-lg whitespace-nowrap"
             onClick={() => {
+              if (!validateForm()) {
+                alert('모든 항목을 입력해주세요.');
+                return;
+              }
               localStorage.setItem('draftForm', JSON.stringify(form));
               router.push('/addExp');
             }}

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -90,6 +90,11 @@ export default function ExpForm({ data }: ExpFormProps) {
   }, []);
 
   const handleAddExperienceTab = (currentExperienceType: ExpType) => {
+    if (forms.length >= 4) {
+      alert('경험은 최대 4개까지 추가할 수 있습니다.');
+      return;
+    }
+
     const isAward =
       currentExperienceType === 'PRIZE' ||
       currentExperienceType === 'CERTIFICATES';
@@ -389,12 +394,14 @@ export default function ExpForm({ data }: ExpFormProps) {
             </div>
           ))}
           {/*경험 항목*/}
-          <div
-            className="w-48 h-20 'bg-black border border-gray-700 rounded-tl-2xl rounded-tr-2xl"
-            onClick={() => handleAddExperienceTab(form.experienceType)}
-          >
-            <PlusGrayIcon className="flex mx-19.5 my-4.5 w-[27px] h-[27px] cursor-pointer" />
-          </div>
+          {forms.length < 4 && (
+            <div
+              className="w-48 h-20 'bg-black border border-gray-700 rounded-tl-2xl rounded-tr-2xl"
+              onClick={() => handleAddExperienceTab(form.experienceType)}
+            >
+              <PlusGrayIcon className="flex mx-19.5 my-4.5 w-[27px] h-[27px] cursor-pointer" />
+            </div>
+          )}
         </div>
         {/*회색 배경*/}
         <div className="pt-[14px] z-0 relative bg-gray-700 rounded-2xl px-12">

--- a/app/(main)/addExp/components/FileInput.tsx
+++ b/app/(main)/addExp/components/FileInput.tsx
@@ -33,30 +33,32 @@ export default function FileInput({
 
   useEffect(() => {
     // 초기 파일이 있을 경우 설정
-    if (initialFiles.length > 0) {
-      const initialItems = initialFiles.map(fileUrl => ({
-        id: Date.now() + Math.random(),
-        uploadType: 'FILE' as UploadType,
-        file: {
-          name: extractFileName(fileUrl), // 파일명 추출 함수 필요
-          url: fileUrl,
-        },
-        link: '',
-        newLink: '',
-      }));
-      setItems(initialItems);
-    } else {
-      setItems([
-        {
-          id: Date.now(),
-          uploadType: 'FILE',
-          file: null,
+    if (items.length === 0) {
+      if (initialFiles.length > 0) {
+        const initialItems = initialFiles.map(fileUrl => ({
+          id: Date.now() + Math.random(),
+          uploadType: 'FILE' as UploadType,
+          file: {
+            name: extractFileName(fileUrl), // 파일명 추출 함수 필요
+            url: fileUrl,
+          },
           link: '',
           newLink: '',
-        },
-      ]);
+        }));
+        setItems(initialItems);
+      } else {
+        setItems([
+          {
+            id: Date.now(),
+            uploadType: 'FILE',
+            file: null,
+            link: '',
+            newLink: '',
+          },
+        ]);
+      }
     }
-  }, [initialFiles]);
+  }, [initialFiles, items.length]);
 
   const extractFileName = (url: string) => {
     try {
@@ -193,7 +195,9 @@ export default function FileInput({
   };
 
   const handleRemoveLink = (id: number) => {
-    const nextItems = items.filter(item => item.id !== id);
+    const nextItems = items.map(item =>
+      item.id === id ? { ...item, link: '', newLink: '' } : item
+    );
 
     setItems(nextItems);
     onFileChange(extractFilesAndLinks(nextItems));

--- a/app/(main)/addExp/components/KeywordInput.tsx
+++ b/app/(main)/addExp/components/KeywordInput.tsx
@@ -43,13 +43,16 @@ export default function KeywordInput({ value, onChange }: KeywordInputProps) {
   };
 
   return (
-    <div className="w-full flex px-4 py-3 bg-gray-800 rounded border border-gray-700 placeholder:text-gray-300 gap-2.5">
+    <div className="w-full flex px-4 py-3 bg-gray-800 items-center rounded border border-gray-700 placeholder:text-gray-300 gap-2.5">
+      <div className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100 whitespace-nowrap">
+        #태그
+      </div>
       {value.map((tag, index) => (
         <div
           key={index}
-          className="h-6 px-2 bg-gray-300 rounded-[16px] inline-flex justify-center items-center text-gray-1100 text-sm"
+          className="px-4 py-1 bg-gray-300 rounded-[16px] inline-flex justify-center items-center text-gray-1100 text-sm whitespace-nowrap"
         >
-          {tag}
+          #{tag}
         </div>
       ))}
       <input
@@ -57,6 +60,7 @@ export default function KeywordInput({ value, onChange }: KeywordInputProps) {
         onChange={onInputChange}
         onKeyDown={onKeyDown}
         placeholder="#태그 입력 (최대 5개)"
+        className="w-full"
       />
     </div>
   );

--- a/app/(main)/exp/components/BtnFilter.tsx
+++ b/app/(main)/exp/components/BtnFilter.tsx
@@ -19,6 +19,7 @@ export default function BtnFilter({
   const [isOpen, setIsOpen] = useState(false);
   const [selectedType, setSelectedType] = useState<ExpType | null>(null);
   const options = Object.values(EXP_OPTIONS);
+  const selectedOption = options.find(o => o.value === selectedType);
   const [order, setOrder] = useState<'latest' | 'oldest'>('latest');
 
   const handleSelectType = (type: ExpType) => {
@@ -38,10 +39,11 @@ export default function BtnFilter({
   return (
     <div className="flex justify-end relative">
       <div
-        className="flex items-center justify-center w-[125px] h-[40px] bg-gray-1000 border border-gray-50-20 rounded-lg text-gray-300 text-sm"
+        className="flex items-center justify-center px-4 h-[40px] bg-gray-1000 border border-gray-50-20 rounded-lg text-gray-300 text-sm"
         onClick={() => setIsOpen(true)}
       >
-        전체•최신순
+        {selectedOption?.label || '전체'}•
+        {order === 'latest' ? '최신순' : '과거순'}
         <ArrowDownIcon className="w-[24px] h-[24px]" />
       </div>
       {isOpen && (

--- a/app/(main)/exp/components/ExpCard.tsx
+++ b/app/(main)/exp/components/ExpCard.tsx
@@ -62,13 +62,13 @@ export default function ExpCard({
 
   return (
     <div
-      className="relative min-w-[260px] h-[224px] border 
+      className="relative w-[260px] h-[224px] border 
           bg-gray-800 border-gray-50-10
        rounded-[14px] flex flex-col justify-between py-[20px] px-[23px]"
     >
       <div onClick={handleClick} className="flex flex-col cursor-pointer">
         <ExpVariety type={type} />
-        <div className="body-16-sb text-gray-50 mt-[15px] mb-[5px] truncate max-w-[24ch]">
+        <div className="body-16-sb text-gray-50 mt-[15px] mb-[5px] truncate">
           {title}
         </div>
         <ol className="flex flex-col gap-1.5 list-disc ml-4">
@@ -76,7 +76,9 @@ export default function ExpCard({
             .filter(subTitle => subTitle)
             .map((subTitle, index) => (
               <li key={index} className="text-[13px] text-gray-300">
-                {subTitle}
+                <div className="flex">
+                  <span className="truncate">{subTitle}</span>
+                </div>
               </li>
             ))}
         </ol>

--- a/app/(main)/exp/components/ExpDetailContent.tsx
+++ b/app/(main)/exp/components/ExpDetailContent.tsx
@@ -205,7 +205,7 @@ export default function ExpDetailContent({
                     key={idx}
                     className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100"
                   >
-                    #{keyword}
+                    {keyword}
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
## 📌 연관된 이슈

- close #179 

## 📝작업 내용

- 경험 입력 시 필수 항목 명시 
- 태그 입력 수정 
-> 경험 입력에서 태그 예시 첨부 
+ 경험 입력할 때 태그 입력하려면 #먼저 입력하고 키워드 입력 
- subTitle 길이 제한 (카드 가로 길이 제한)
- 경험 카드 필터링/정렬 시 버튼 이름도 같이 바뀌게 변경
- 링크 첨부 시 UI가 파일로 변경되는 오류 / 삭제 시 항목 전부가 삭제되는 오류 해결

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/d84a7b79-74a3-494c-91c0-fa3906ec955f)

![image](https://github.com/user-attachments/assets/7786dd10-a4a6-4617-9278-aea9871cabc6)

## 💬리뷰 요구사항
