### PR TITLE
fix/#181: profile error 처리

### DIFF
--- a/apis/mypage.ts
+++ b/apis/mypage.ts
@@ -1,6 +1,8 @@
 'use server';
 
+import { redirect } from 'next/navigation';
 import API from './config';
+import { AxiosError } from 'axios';
 
 export interface MemberResponse {
   httpStatus: number;
@@ -17,11 +19,20 @@ export interface MemberResponse {
 }
 
 export async function getMemberInfo(): Promise<MemberResponse> {
-  const res = await API.get<MemberResponse>('/api/members');
+  try {
+    const res = await API.get('/api/members');
 
-  if (res.status !== 200) {
-    console.error('멤버 정보 불러오기 실패:', res.data);
+    if (res.status !== 200) {
+      console.log('프로필 정보 불러오기 실패', res.data);
+      redirect('/profile');
+    }
+
+    return res.data;
+  } catch (err) {
+    console.error('프로필 정보 불러오기 실패', err);
+    if (err instanceof AxiosError && err?.response?.status === 500) {
+      redirect('/profile');
+    }
+    redirect('/login');
   }
-
-  return res.data;
 }

--- a/apis/profile.ts
+++ b/apis/profile.ts
@@ -19,16 +19,21 @@ export interface ProfileInfo {
 }
 
 export async function getProfileInfo(): Promise<ProfileInfoResponse> {
-  const res = await API.get('/api/members');
+  try {
+    const res = await API.get('/api/members');
 
-  const { desiredDetailRecruit, educationName } = res.data.data;
+    const { desiredDetailRecruit, educationName } = res.data.data;
 
-  if (res.status !== 200 || !desiredDetailRecruit || !educationName) {
-    console.log('프로필 정보 불러오기 실패', res.data);
+    if (res.status !== 200 || !desiredDetailRecruit || !educationName) {
+      console.log('프로필 정보 불러오기 실패', res.data);
+      redirect('/profile');
+    }
+
+    return res.data;
+  } catch (err) {
+    console.error('프로필 정보 불러오기 실패', err);
     redirect('/profile');
   }
-
-  return res.data;
 }
 
 export async function saveProfileInfo(

--- a/apis/profile.ts
+++ b/apis/profile.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { AxiosError } from 'axios';
 import API from './config';
 import { redirect } from 'next/navigation';
 
@@ -32,7 +33,10 @@ export async function getProfileInfo(): Promise<ProfileInfoResponse> {
     return res.data;
   } catch (err) {
     console.error('프로필 정보 불러오기 실패', err);
-    redirect('/profile');
+    if (err instanceof AxiosError && err?.response?.status === 500) {
+      redirect('/profile');
+    }
+    redirect('/login');
   }
 }
 


### PR DESCRIPTION
## 📌 연관된 이슈

- close #181

## 📝작업 내용

프로필 정보 중 일부가 null일 때는 500이 안뜨는데(카카오 로그인) 정보가 아예 없을 경우 500이 떠서 프로필 정보 미입력 시 /profile로 라우팅되게 했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항
profile.ts와 mypage.ts에서 동일한 api를 호출 중인데 하나로 통일하는 게 좋을 것 같아요! 일단 mypage.ts도 에러 처리 같이 했습니다