### PR TITLE
Feat/#173/dashboard client error, 타임라인 스크롤바 추가

### DIFF
--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -53,7 +53,6 @@ export default function ExpTimeLine({
           newMax.toISOString().split('T')[0]
         );
         const timeline = response.data;
-        console.log('경험 타임라인:', timeline);
 
         if (!Array.isArray(timeline) || timeline.length === 0) {
           return;

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -50,6 +50,12 @@ export default function Timeline({
   const totalDays = Math.max(differenceInDays(maxDate, minDate), 1);
   const gap = 20;
 
+  const maxRowIndex =
+    placedBar.length > 0 ? Math.max(...placedBar.map(bar => bar.rowIndex)) : 0;
+
+  const totalSvgHeight =
+    maxRowIndex >= 3 ? maxRowIndex * (30 + gap) + 30 + gap : height;
+
   useEffect(() => {
     if (!numericWidth) return;
 
@@ -88,12 +94,18 @@ export default function Timeline({
   return (
     <div
       ref={containerRef}
-      className="flex justify-center mx-[30px] pt-[10px] bg-gray-600-20 rounded-lg overflow-hidden"
+      className="flex justify-center mx-[30px] bg-gray-600-20 rounded-lg overflow-hidden"
+      style={{ maxHeight: height, overflowY: 'auto' }}
     >
       <svg
         width={numericWidth}
-        height={height}
-        style={{ background: 'transparent', width: `${numericWidth}px` }}
+        height={totalSvgHeight}
+        style={{
+          background: 'transparent',
+          width: `${numericWidth}px`,
+          display: 'block',
+          padding: '10px 0 10px 0',
+        }}
       >
         {placedBar.map((exp, idx) => {
           const h = 30;

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -33,14 +33,6 @@ function formatDate(dateStr: string): string {
   return dateStr.replace(/-/g, '.');
 }
 
-function measureTextWidth(text: string, font = '14px sans-serif'): number {
-  const canvas = document.createElement('canvas');
-  const context = canvas.getContext('2d');
-  if (!context) return 0;
-  context.font = font;
-  return context.measureText(text).width;
-}
-
 export default function Timeline({
   exps,
   width = '100%',
@@ -70,7 +62,8 @@ export default function Timeline({
         const x1 =
           (differenceInDays(_start, minDate) / totalDays) * numericWidth;
         const x2 = (differenceInDays(_end, minDate) / totalDays) * numericWidth;
-        const textWidth = measureTextWidth(exp.title);
+        const textWidth = (exp.title?.length || 0) * 7.5;
+
         return { ...exp, _start, _end, x1, x2, textWidth };
       })
       .sort((a, b) => a.x1 - b.x1)


### PR DESCRIPTION
## 📌 연관된 이슈

- close #173 

## 📝작업 내용
client 에러 처리하고 겹치는 경험 많을 시 스크롤바 구현했습니다

기존 코드는 text길이를 측정할 때 canvas 렌더링 후 폰트 크기 기반으로 text길이를 측정했는데, 서버에서 렌더링 시 canvas 기반으로 측정이 불가하고 이로 인해 hydration error가 발생했습니다.

경험 기간과 타이틀 글자가 겹치는 경우 줄바꿈을 위해 텍스트 크기를 측정하고 이를 기반으로 줄바꿈했는데, 완전히 정확히 측정하지 않아도 ui에서 티가 나는 부분이 아니며 하이드레이션 에러를 해결하기 위해 클라이언트에서 렌더링 시 로딩 속도 및 깜빡임의 우려가 있어 타이틀 글자 길이 기반으로 텍스트 길이를 측정하여 줄바꿈하도록 변경했습니다.

경험 여러개 중첩 시 스크롤 기능도 구현했습니다!

### 스크린샷 (선택)

https://github.com/user-attachments/assets/1fb9fda5-24ff-4597-a783-90fb34783ad6

## 💬리뷰 요구사항
