### PR TITLE
Fix/#186 마이페이지 QA 요청사항 반영

### DIFF
--- a/apis/guide.ts
+++ b/apis/guide.ts
@@ -31,6 +31,22 @@ interface GetAIResponse {
   };
 }
 
+export interface AIActivityDetail {
+  scrapId: number;
+  scrapType: 'ACTIVITY' | 'INTERN' | 'COMPETITION' | 'EDUCATION';
+  title: string;
+  imageUrl: string;
+  referenceUrl: string;
+  jobCategory: string[];
+  startDate: string;
+  endDate: string;
+  eligibility?: string;
+  benefits?: string;
+  enterpriseType?: string;
+  region?: string;
+  onOffLine?: string;
+}
+
 export async function getWeakness(): Promise<GetWeakResponse> {
   try {
     const res = await API.get<GetWeakResponse>('/api/guide/weakness');
@@ -63,5 +79,17 @@ export async function getAIActivityByIndex(
         content: [],
       },
     };
+  }
+}
+
+export async function getAIActivityDetail(
+  id: number
+): Promise<AIActivityDetail | null> {
+  try {
+    const res = await API.get(`/api/guide/activities/${id}`);
+    return res.data?.data ?? null;
+  } catch (e) {
+    console.error('상세 활동 조회 실패:', e);
+    return null;
   }
 }

--- a/app/(main)/guide/[id]/page.tsx
+++ b/app/(main)/guide/[id]/page.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter, useParams } from 'next/navigation';
+import { getAIActivityDetail } from '@/apis/guide';
+import { EXP_STYLES } from '@/constants/expStyles';
+import BackIcon from '@/public/icons/Chevron_Left.svg';
+import { useEffect, useState } from 'react';
+import type { AIActivityDetail } from '@/apis/guide';
+
+const SCRAP_TYPE_MAP = {
+  ACTIVITY: 'EXTERNAL_ACTIVITIES',
+  INTERN: 'INTERN',
+  COMPETITION: 'CONTEST',
+  EDUCATION: 'EDUCATION',
+} as const;
+
+const SCRAP_TYPE_LABEL_MAP: Record<string, string> = {
+  ACTIVITY: '대외활동',
+  INTERN: '인턴',
+  COMPETITION: '공모전',
+  EDUCATION: '교육',
+};
+
+export default function GuideDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const id = Number(params.id);
+
+  const [data, setData] = useState<AIActivityDetail | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      const result = await getAIActivityDetail(id);
+      if (result) {
+        setData(result);
+      } else {
+        console.error('상세 정보가 없습니다.');
+      }
+    })();
+  }, [id]);
+
+  if (!data) return null;
+
+  const styleKey = SCRAP_TYPE_MAP[data.scrapType] ?? 'ETC';
+  const typeStyle = EXP_STYLES[styleKey];
+  const scrapTypeLabel = SCRAP_TYPE_LABEL_MAP[data.scrapType] ?? data.scrapType;
+
+  return (
+    <div className="min-h-screen bg-black text-white px-6 py-10">
+      {/* 제목 + 뒤로가기 */}
+      <div className="flex items-center gap-4 mb-8">
+        <button
+          type="button"
+          onClick={() => router.push('/guide')}
+          aria-label="뒤로가기"
+        >
+          <BackIcon className="stroke-gray-50 w-[35px] h-[35px] cursor-pointer" />
+        </button>
+
+        <h1 className="text-[25px] font-bold flex items-center justify-center gap-2">
+          {data.title}
+          <span className={`text-xs px-2 py-1 rounded-2xl ${typeStyle}`}>
+            {scrapTypeLabel}
+          </span>
+        </h1>
+      </div>
+
+      {/* 본문 내용 */}
+      <div className="flex flex-col lg:flex-row gap-10 bg-gray-800 rounded-xl p-10 xl:p-15">
+        {/* 설명 영역 */}
+        <div className="basis-1/2 text-gray-300 space-y-5">
+          <Detail label="주제" value={data.jobCategory.join(', ')} />
+          <Detail
+            label="모집 기간"
+            value={`${data.startDate} ~ ${data.endDate}`}
+          />
+          {data.eligibility && (
+            <Detail label="지원 자격" value={data.eligibility} />
+          )}
+          {data.benefits && <Detail label="혜택" value={data.benefits} />}
+          {data.enterpriseType && (
+            <Detail label="기업 형태" value={data.enterpriseType} />
+          )}
+          {data.region && <Detail label="지역" value={data.region} />}
+          {data.onOffLine && (
+            <Detail label="진행 방식" value={data.onOffLine} />
+          )}
+          <Detail
+            label="웹사이트"
+            value={
+              data.referenceUrl !== '-' ? (
+                <a
+                  href={data.referenceUrl}
+                  target="_blank"
+                  className="text-gray-300 underline hover:text-primary"
+                >
+                  {data.referenceUrl}
+                </a>
+              ) : (
+                '없음'
+              )
+            }
+          />
+        </div>
+
+        {/* 이미지 영역 */}
+        <div className="basis-1/2">
+          <Image
+            src={data.imageUrl}
+            alt={data.title}
+            width={400}
+            height={600}
+            className="rounded-lg w-full h-auto"
+            unoptimized
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-4 xl:gap-10 mb-8 xl:mb-10">
+      <div className="w-24 shrink-0 text-[18px] xl:text-[20px] text-white leading-relaxed">
+        {label}
+      </div>
+      <div className="flex-1 text-[18px] xl:text-[20px] text-gray-300 leading-relaxed whitespace-pre-wrap">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/guide/components/AIActivityCard.tsx
+++ b/app/(main)/guide/components/AIActivityCard.tsx
@@ -2,6 +2,7 @@
 
 import { AIActivity } from '@/apis/guide';
 import { addScrap, removeScrap } from '@/apis/scrap';
+import { EXP_STYLES } from '@/constants/expStyles';
 import BookmarkIcon from '@/public/icons/Bookmark.svg';
 import BookmarkFill from '@/public/icons/Bookmark_fill.svg';
 import Image from 'next/image';
@@ -13,6 +14,20 @@ interface AIActivityProps {
   onScrapToggle?: (id: number) => void;
 }
 
+const SCRAP_TYPE_STYLE_MAP: Record<string, keyof typeof EXP_STYLES> = {
+  ACTIVITY: 'EXTERNAL_ACTIVITIES',
+  INTERN: 'INTERN',
+  COMPETITION: 'CONTEST',
+  EDUCATION: 'EDUCATION',
+};
+
+const SCRAP_TYPE_LABEL_MAP: Record<string, string> = {
+  ACTIVITY: '대외활동',
+  INTERN: '인턴',
+  COMPETITION: '공모전',
+  EDUCATION: '교육',
+};
+
 export default function AIActivityCard({
   data,
   onScrapToggle,
@@ -20,6 +35,10 @@ export default function AIActivityCard({
   const [isCliped, setIsCliped] = useState(data.isCliped);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+
+  const styleKey = SCRAP_TYPE_STYLE_MAP[data.scrapType] ?? 'ETC';
+  const typeStyle = EXP_STYLES[styleKey];
+  const typeLabel = SCRAP_TYPE_LABEL_MAP?.[data.scrapType] ?? data.scrapType;
 
   const handleToggleScrap = async (
     e: React.MouseEvent<HTMLDivElement, MouseEvent>
@@ -72,7 +91,9 @@ export default function AIActivityCard({
 
         {/* 스크랩 정보 */}
         <div className="flex items-center justify-between pt-6">
-          <span className="text-sm text-gray-200">{data.scrapType}</span>
+          <span className={`text-xs px-2 py-1 rounded-xl ${typeStyle}`}>
+            {typeLabel}
+          </span>
           <div onClick={handleToggleScrap} className="cursor-pointer">
             {isCliped ? (
               <BookmarkFill className="stroke-gray-100 w-5 h-5" />

--- a/app/(main)/guide/components/AIActivityCard.tsx
+++ b/app/(main)/guide/components/AIActivityCard.tsx
@@ -5,6 +5,7 @@ import { addScrap, removeScrap } from '@/apis/scrap';
 import BookmarkIcon from '@/public/icons/Bookmark.svg';
 import BookmarkFill from '@/public/icons/Bookmark_fill.svg';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 interface AIActivityProps {
@@ -18,8 +19,12 @@ export default function AIActivityCard({
 }: AIActivityProps) {
   const [isCliped, setIsCliped] = useState(data.isCliped);
   const [loading, setLoading] = useState(false);
+  const router = useRouter();
 
-  const handleToggleScrap = async () => {
+  const handleToggleScrap = async (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    e.stopPropagation(); // 카드 클릭 이벤트 방지
     if (loading) return;
     setLoading(true);
 
@@ -28,7 +33,7 @@ export default function AIActivityCard({
         const success = await removeScrap(data.id);
         if (success) {
           setIsCliped(false);
-          onScrapToggle?.(data.id); // ✅ 스크랩 해제 시 부모에 알림
+          onScrapToggle?.(data.id);
         }
       } else {
         const success = await addScrap(data.id);
@@ -42,8 +47,15 @@ export default function AIActivityCard({
     }
   };
 
+  const handleCardClick = () => {
+    router.push(`/guide/${data.id}`);
+  };
+
   return (
-    <div className="w-65 h-125 px-5 py-4.5 bg-[#1A1A1A] rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 flex flex-col justify-between mb-5">
+    <div
+      onClick={handleCardClick}
+      className="w-65 h-125 px-5 py-4.5 bg-[#1A1A1A] rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 flex flex-col justify-between mb-5 cursor-pointer"
+    >
       <div>
         {/* 이미지 */}
         <div className="w-full h-60 rounded-md overflow-hidden">
@@ -70,7 +82,7 @@ export default function AIActivityCard({
           </div>
         </div>
 
-        {/* 제목*/}
+        {/* 제목 */}
         <div className="pt-5 body-20-r text-gray-50 break-words whitespace-normal">
           {data.title}
         </div>

--- a/app/(main)/myPage/page.tsx
+++ b/app/(main)/myPage/page.tsx
@@ -67,19 +67,20 @@ export default function MyPage() {
       {/* 프로필 이미지 */}
       <div className="relative w-40 h-40 mb-20">
         <Image
-          src={member.imgurl}
+          // src={member.imgurl}
+          src="/images/mainprofile.svg"
           alt="프로필 이미지"
           fill
           className="rounded-full object-cover border border-gray-600"
         />
-        <div className="absolute bottom-1 right-2 bg-black rounded-full w-6 h-6 flex items-center justify-center text-xs">
+        {/* <div className="absolute bottom-1 right-2 bg-black rounded-full w-6 h-6 flex items-center justify-center text-xs">
           <Image
             src="/images/btnProfileImg.svg"
             alt="upload"
             width={40}
             height={40}
           />
-        </div>
+        </div> */}
       </div>
 
       {/* 프로필 정보 */}

--- a/app/components/BtnMenu.tsx
+++ b/app/components/BtnMenu.tsx
@@ -1,4 +1,7 @@
-import Link from 'next/link';
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 interface BtnMenuProps {
   title: string;
@@ -6,11 +9,28 @@ interface BtnMenuProps {
 }
 
 export default function BtnMenu({ title, menu }: BtnMenuProps) {
+  const router = useRouter();
+  const [hasToken, setHasToken] = useState(false);
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    setHasToken(!!token);
+  }, []);
+
+  const handleClick = () => {
+    if (!hasToken) {
+      alert('로그인 후 이용할 수 있습니다.');
+      return;
+    }
+    router.push(`/${menu}`);
+  };
+
   return (
-    <Link href={`/${menu}`}>
-      <div className="text-gray-50 hover:text-primary-50 active:text-primary-100">
-        {title}
-      </div>
-    </Link>
+    <div
+      onClick={handleClick}
+      className="text-gray-50 hover:text-primary-50 active:text-primary-100 cursor-pointer"
+    >
+      {title}
+    </div>
   );
 }

--- a/app/components/InputCheckBox.tsx
+++ b/app/components/InputCheckBox.tsx
@@ -6,6 +6,7 @@ interface InputBoxProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   successHighlight?: boolean;
+  showCheckIcon?: boolean;
 }
 
 const InputBox = ({
@@ -15,6 +16,7 @@ const InputBox = ({
   onChange,
   error,
   successHighlight = false,
+  showCheckIcon = true,
 }: InputBoxProps) => {
   const isSuccess = successHighlight && !error && value?.trim();
 
@@ -36,12 +38,14 @@ const InputBox = ({
                   : 'border-[#161616]'
             }`}
         />
-        <span
-          className={`absolute right-4 top-1/2 transform -translate-y-1/2 transition 
-            ${error ? 'text-error' : isSuccess ? 'text-success' : 'text-gray-400'}`}
-        >
-          ✔
-        </span>
+        {showCheckIcon && (
+          <span
+            className={`absolute right-4 top-1/2 transform -translate-y-1/2 transition 
+              ${error ? 'text-error' : isSuccess ? 'text-success' : 'text-gray-400'}`}
+          >
+            ✔
+          </span>
+        )}
       </div>
       {error && <p className="text-error text-[14px] mt-1 ml-1">{error}</p>}
     </>

--- a/app/components/Profile.tsx
+++ b/app/components/Profile.tsx
@@ -1,37 +1,48 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
+// import Link from 'next/link';
 import Image from 'next/image';
 import ArrowDownIcon from '@/public/icons/Arrow_Down.svg';
 import { logout } from '@/apis/auth';
 import { ProfileInfo } from '@/apis/profile';
+import { useRouter } from 'next/navigation';
 
 export default function Profile({ profileInfo }: { profileInfo: ProfileInfo }) {
   const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+
+  const handleImageClick = () => {
+    router.push('/myPage');
+  };
 
   return (
     <div className="flex justify-end relative">
       <div className="flex items-center justify-center gap-1.5 text-gray-50 font-semibold">
-        <Image
-          src={profileInfo.imgurl || '/images/mainprofile.svg'}
-          alt="profile"
-          width={36}
-          height={36}
-        />
-        <p className="whitespace-nowrap">{profileInfo.name}</p>
+        <div
+          onClick={handleImageClick}
+          className="cursor-pointer flex gap-2 justify-center items-center"
+        >
+          <Image
+            src={profileInfo.imgurl || '/images/mainprofile.svg'}
+            alt="profile"
+            width={36}
+            height={36}
+          />
+          <p className="whitespace-nowrap">{profileInfo.name}</p>
+        </div>
         <ArrowDownIcon
           onClick={() => setIsOpen(!isOpen)}
           className="w-[24px] h-[24px]"
         />
         {isOpen && (
           <div className="flex flex-col absolute top-full justify-center">
-            <div className="flex bg-gray-800 w-44 px-5 py-2.5 text-gray-50 text-xs">
+            {/* <div className="flex bg-gray-800 w-44 px-5 py-2.5 text-gray-50 text-xs">
               <Link href="/myPage">마이페이지</Link>
             </div>
             <div className="flex bg-gray-800 w-44 px-5 py-2.5 text-gray-50 text-xs">
               <Link href="/scrap">스크랩</Link>
-            </div>
+            </div> */}
             <form action={logout}>
               <button
                 type="submit"

--- a/app/login/components/LoginForm.tsx
+++ b/app/login/components/LoginForm.tsx
@@ -110,6 +110,7 @@ export default function LoginForm() {
           value={email}
           onChange={handleEmailChange}
           error={emailError}
+          showCheckIcon={false}
         />
       </div>
       <div>
@@ -120,6 +121,7 @@ export default function LoginForm() {
           value={password}
           onChange={handlePasswordChange}
           error={passwordError}
+          showCheckIcon={false}
         />
       </div>
 

--- a/app/profile/components/ProfileForm.tsx
+++ b/app/profile/components/ProfileForm.tsx
@@ -355,6 +355,7 @@ export default function ProfileForm({
         schools={schoolList}
         onSelect={school => {
           setSelectedSchool(school);
+          setSelectedMajor('');
           setSchoolSearchInput('');
         }}
         searchValue={schoolSearchInput}


### PR DESCRIPTION
## 📌 연관된 이슈

- close #186 

## 📝작업 내용
- 페이지의 프로필 드롭다운 필요 없는 것 같음 (마이페이지/스크랩/로그아웃이 있는데 다른 것들은 사이드바에 있으니까 드롭다운 없애고 로그아웃 텍스트만 있는 게 어떤가) ⇒ 내일 회의 때 디자이너님 의견에 따라서 최종적으로 수정해두겠습니다.
- ~~로그아웃 시 상단바 메뉴 클릭 안됨~~ 
⇒ 원래 로그인한 사용자만 사용할 수 있는 기능이라서, 클릭해도 계속 로그인 페이지에 있는게 맞습니다. 일단 로그인 후 사용할 수 있다는 알림 뜨게 해두었습니다.
- ~~로그인할 때 체크 표시 제거~~
- ~~편집 전에 사진 아이콘 제거 (편집 시에만 사진 변경 가능하니까)~~
- 마이페이지 사진 변경 안됨⇒ 연동 중입니다...
- ~~학력 입력 시 학과 설정 후 다시 대학 설정할 때 학과 초기화되게 변경 필요~~
- ~~프로필 사진 클릭 시 마이페이지로 이동가능하면 편할듯~~

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4907a479-0780-4b19-86ec-3e4fc70b4f70)


## 💬리뷰 요구사항
