### PR TITLE
Fix/#192/경험 페이지 UT 피드백 반영

### DIFF
--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -282,6 +282,7 @@ export default function ExpForm({
 
     const payload: ExpPayload = {
       ...form,
+      title: form.title,
       issueDate: form.issueDate
         ? new Date(form.issueDate).toISOString()
         : undefined,

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -85,8 +85,6 @@ export default function ExpForm({
     return [getInitialForm(data)];
   });
   const [activeFormIndex, setActiveFormIndex] = useState(0);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [editingValue, setEditingValue] = useState('');
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [pendingFormType, setPendingFormType] = useState<ExpFormType | null>(
@@ -163,26 +161,6 @@ export default function ExpForm({
 
       return updatedForms;
     });
-  };
-
-  const handleDoubleClickTab = (index: number) => {
-    setEditingIndex(index);
-    setEditingValue(forms[index].tabName || `경험 ${index + 1}`);
-  };
-
-  const handleSaveTabName = (index: number) => {
-    setForms(prev => {
-      const updated = [...prev];
-      updated[index] = {
-        ...updated[index],
-        tabName:
-          editingValue.trim() === ''
-            ? `경험 ${index + 1}`
-            : editingValue.trim(),
-      };
-      return updated;
-    });
-    setEditingIndex(null);
   };
 
   const isFormChanged = () => {
@@ -414,37 +392,33 @@ export default function ExpForm({
                   className="mx-41 my-2.5 w-4 h-4"
                 />
               )}
-              <div
-                className={`flex h-full justify-center text-lg ${
-                  forms.length > 1 ? 'mt-[-10px]' : 'mt-[22px]'
-                }`}
-                onDoubleClick={e => {
-                  e.stopPropagation();
-                  handleDoubleClickTab(index);
-                }}
-              >
-                {editingIndex === index ? (
-                  <input
-                    type="text"
-                    className="w-[100px] h-[30px] bg-[#5B5B5B] px-2 py-1"
-                    value={editingValue}
-                    autoFocus
-                    onChange={e => setEditingValue(e.target.value)}
-                    onBlur={() => handleSaveTabName(index)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') {
-                        handleSaveTabName(index);
-                      }
-                    }}
-                  />
-                ) : (
-                  <div className="truncate max-w-[10ch]">
-                    {forms[index].tabName || `경험 ${index + 1}`}
-                  </div>
-                )}
+              <div className="flex h-full justify-center text-lg mt-[10px]">
+                <input
+                  type="text"
+                  className="absolute top-73 w-[100px] h-[30px] bg-[#5B5B5B] px-2 py-1 text-center rounded"
+                  value={forms[index].tabName ?? ''}
+                  placeholder={`경험 ${index + 1}`}
+                  onChange={e => {
+                    const newTabName = e.target.value;
+                    setForms(prev => {
+                      const updated = [...prev];
+                      updated[index] = {
+                        ...updated[index],
+                        tabName: newTabName,
+                      };
+                      return updated;
+                    });
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                    }
+                  }}
+                />
               </div>
             </div>
           ))}
+
           {/*경험 항목*/}
           {forms.length < 4 && (
             <div

--- a/app/(main)/addExp/components/ExpForm.tsx
+++ b/app/(main)/addExp/components/ExpForm.tsx
@@ -229,7 +229,10 @@ export default function ExpForm({
       setForms(prev => {
         const updated = [...prev];
         updated[activeFormIndex] = {
-          ...getInitialForm(undefined),
+          ...getInitialForm({
+            ...forms[activeFormIndex],
+            subExperiencesResponseDto: [],
+          }),
           formType: pendingFormType,
           selectedTab: pendingFormType === 'STAR_FORM' ? 'star' : 'simple',
           experienceType: forms[activeFormIndex].experienceType,

--- a/app/(main)/addExp/components/KeywordInput.tsx
+++ b/app/(main)/addExp/components/KeywordInput.tsx
@@ -45,7 +45,7 @@ export default function KeywordInput({ value, onChange }: KeywordInputProps) {
   return (
     <div className="w-full flex px-4 py-3 bg-gray-800 items-center rounded border border-gray-700 placeholder:text-gray-300 gap-2.5">
       <div className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100 whitespace-nowrap">
-        #키워드 입력
+        #키워드
       </div>
       {value.map((tag, index) => (
         <div

--- a/app/(main)/addExp/components/KeywordInput.tsx
+++ b/app/(main)/addExp/components/KeywordInput.tsx
@@ -45,7 +45,7 @@ export default function KeywordInput({ value, onChange }: KeywordInputProps) {
   return (
     <div className="w-full flex px-4 py-3 bg-gray-800 items-center rounded border border-gray-700 placeholder:text-gray-300 gap-2.5">
       <div className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100 whitespace-nowrap">
-        #태그
+        #키워드 입력
       </div>
       {value.map((tag, index) => (
         <div
@@ -59,7 +59,7 @@ export default function KeywordInput({ value, onChange }: KeywordInputProps) {
         value={input}
         onChange={onInputChange}
         onKeyDown={onKeyDown}
-        placeholder="#태그 입력 (최대 5개)"
+        placeholder="키워드 입력 (최대 5개)"
         className="w-full"
       />
     </div>

--- a/app/(main)/addExp/components/SimpleForm.tsx
+++ b/app/(main)/addExp/components/SimpleForm.tsx
@@ -54,7 +54,7 @@ export default function SimpleForm({ data, onChange }: SimpleFormProps) {
 
       <div className="py-15">
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
-          자료 첨부(선택)
+          자료 첨부
         </div>
         <FileInput
           onFileChange={newFiles => handleChange('files', newFiles)}

--- a/app/(main)/addExp/components/StarForm.tsx
+++ b/app/(main)/addExp/components/StarForm.tsx
@@ -78,7 +78,7 @@ export default function StarForm({ data, onChange }: StarFormProps) {
 
       <div className="py-15">
         <div className="text-gray-50 text-xl font-medium mb-[2%] ml-[1%]">
-          자료 첨부(선택)
+          자료 첨부
         </div>
         <FileInput
           onFileChange={newFiles => handleChange('files', newFiles)}

--- a/app/(main)/exp/components/AddExpBtn.tsx
+++ b/app/(main)/exp/components/AddExpBtn.tsx
@@ -29,7 +29,7 @@ export default function AddExpBtn({ form, onChange }: AddExpBtnProps) {
       >
         경험 추가
       </div>
-      <div className="absolute flex items-center justify-center top-0 right-0 w-20 h-20 bg-primary-50 active:bg-primary-100 rounded-full z-20">
+      <div className="absolute flex items-center justify-center top-0 right-0 w-20 h-20 bg-primary-50 hover:bg-primary-100 rounded-full z-20">
         <EditPencilIcon
           className="stroke-gray-1100 w-[30px] h-[30px]"
           onClick={() => setIsModalOpen(true)}

--- a/app/(main)/exp/components/ExpCard.tsx
+++ b/app/(main)/exp/components/ExpCard.tsx
@@ -65,9 +65,12 @@ export default function ExpCard({
       className="relative w-[260px] h-[224px] border 
           bg-gray-800 border-gray-50-10
        rounded-[14px] flex flex-col justify-between py-[20px] px-[23px]"
-      onClick={handleClick}
     >
-      <div className="flex flex-col cursor-pointer">
+      <div
+        className="flex flex-col cursor-pointer"
+        onClick={handleClick}
+        style={{ width: '200px', height: '200px' }}
+      >
         <ExpVariety type={type} />
         <div className="body-16-sb text-gray-50 mt-[15px] mb-[5px] truncate">
           {title}
@@ -92,12 +95,13 @@ export default function ExpCard({
             <span>임시저장</span>
           </div>
         )}
-        <button className="flex w-full justify-end cursor-pointer">
+
+        <div className="flex w-full justify-end">
           <MoreVerticalIcon
-            className=" stroke-gray-50 "
+            className=" stroke-gray-50 cursor-pointer"
             onClick={() => setIsDropdownOpen(prev => !prev)}
           />
-        </button>
+        </div>
         {isDropdownOpen && (
           <DropdownMenu
             id={id}

--- a/app/(main)/exp/components/ExpDetailContent.tsx
+++ b/app/(main)/exp/components/ExpDetailContent.tsx
@@ -208,7 +208,7 @@ export default function ExpDetailContent({
                     key={idx}
                     className="px-4 py-1 bg-gray-300 text-sm rounded-full text-gray-1100"
                   >
-                    {keyword}
+                    #{keyword}
                   </span>
                 ))}
               </div>

--- a/constants/expStyles.ts
+++ b/constants/expStyles.ts
@@ -1,6 +1,6 @@
 export const EXP_STYLES = {
   CONTEST: 'text-pink-50 bg-pink-50-20',
-  EXTERNAL_ACTIVITIES: 'text-red-50 bg-red-50-20',
+  EXTERNAL_ACTIVITIES: 'text-apricot-50 bg-apricot-50-20',
   ACADEMIC_CLUB: 'text-blue-50 bg-blue-50-20',
   PROJECT: 'text-plum-50 bg-plum-50-20',
   EDUCATION: 'text-mint-50 bg-mint-50-20',


### PR DESCRIPTION
## 📌 연관된 이슈

- close #192 

## 📝작업 내용

- keywordInput 수정 : 입력할 때는 # 없이, enter치면 #붙은 태그 생성, 상세 페이지에서도 #붙은 태그로 확인 가능
- 간결 양식일 때 title, date 정보 전달되게 수정 (tab 변경 시 초기화된 데이터가 넘어가서 active된 form 정보 넘어가게 수정)
- 경험 카드 제목부터 임시저장 부분 전까지(200x200) 영역만 클릭했을 때 상세페이지로 넘어가게 수정
- 대외활동 color apricot-50으로 수정
- tabName input으로 변경 

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/d49aec4f-5a4f-473e-9dc7-97776c22a18c)

## 💬리뷰 요구사항
