### PR TITLE
fix/#207: 대시보드 최대 길이 변경, 월 수 4개 고정, 추천 경험 없을 시 안내 문구 수정

### DIFF
--- a/app/(main)/dashboard/components/ExpTimeLine.tsx
+++ b/app/(main)/dashboard/components/ExpTimeLine.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/apis/dashboard';
 import BtnNext from '@/app/components/commons/BtnNext';
 import BtnPrev from '@/app/components/commons/BtnPrev';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import DashboardHeader from './DashboardHeader';
 import { DASHBOARD_INFO } from '@/constants/dashboardInfo';
 
@@ -26,13 +26,15 @@ export default function ExpTimeLine({
   const [experiences, setExperiences] = useState<TimelineExp[]>(
     expTimeline.data
   );
+  console.log(expTimeline.data);
 
-  const monthLabels: string[] = [];
-  const dt = new Date(minDate.getFullYear(), minDate.getMonth(), 1);
-  while (dt.getMonth() <= maxDate.getMonth()) {
-    monthLabels.push(`${dt.getMonth() + 1}월`);
-    dt.setMonth(dt.getMonth() + 1);
-  }
+  const monthLabels = useMemo(() => {
+    const start = new Date(minDate.getFullYear(), minDate.getMonth(), 1);
+    return [0, 1, 2, 3].map(i => {
+      const dt = new Date(start.getFullYear(), start.getMonth() + i, 1);
+      return `${dt.getMonth() + 1}월`;
+    });
+  }, [minDate]);
 
   // 1달 이전으로 이동
   const handlePrev = () => {

--- a/app/(main)/guide/page.tsx
+++ b/app/(main)/guide/page.tsx
@@ -205,11 +205,11 @@ export default function GuidePage() {
 
       {isActivityLoading ? (
         <LoadingSpinner />
-      ) : activities && activities.length > 0 ? (
+      ) : 0 ? (
         <AIList data={activities} />
       ) : (
         <div className="text-gray-400 text-center py-10">
-          AI 추천 경험이 없습니다.
+          {selectedFilter?.map(f => f).join(', ')} 관련 AI 추천 활동이 없습니다.
         </div>
       )}
       <Footer />

--- a/app/components/commons/Timeline.tsx
+++ b/app/components/commons/Timeline.tsx
@@ -54,7 +54,7 @@ export default function Timeline({
     placedBar.length > 0 ? Math.max(...placedBar.map(bar => bar.rowIndex)) : 0;
 
   const totalSvgHeight =
-    maxRowIndex >= 3 ? maxRowIndex * (30 + gap) + 30 + gap : height;
+    maxRowIndex >= 3 ? maxRowIndex * (30 + gap) + 50 + gap : height;
 
   useEffect(() => {
     if (!numericWidth) return;


### PR DESCRIPTION
## 📌 연관된 이슈

- close #이슈 번호

## 📝작업 내용
대시보드 최대 길이 변경, 월 수 4개 고정, 추천 경험 없을 시 안내 문구 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항
